### PR TITLE
SWM_LIB uses full path for libswmhack.so.$(LVERS)

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -1,5 +1,5 @@
 CFLAGS+= -std=c99 -Wmissing-prototypes -Wall -Wextra -Wshadow -Wno-uninitialized -g
-CFLAGS+= -D_GNU_SOURCE -I. -I/usr/include/freetype2 -DSWM_LIB=\"libswmhack.so.$(LVERS)\"
+CFLAGS+= -D_GNU_SOURCE -I. -I/usr/include/freetype2 -DSWM_LIB=\"$(LIBDIR)/libswmhack.so.$(LVERS)\"
 LDADD+= -lX11 -lX11-xcb -lxcb -lxcb-icccm -lxcb-randr -lxcb-keysyms -lxcb-util -lxcb-xtest -lXft -lXcursor
 
 PREFIX?= /usr/local


### PR DESCRIPTION
Not sure why the $(LIBDIR) prefix was removed. this causes $LD_PRELOAD to be set to libswmhack.so.$(LVERS) instead of the full path, and then launching a new process complains of not finding libswmhack.so.0.0.

Something I miss?
