### PR TITLE
Add quirk so a window will always open in the active workspace

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -948,6 +948,9 @@ When an application requests focus on the window via a _NET_ACTIVE_WINDOW
 client message (source indication of 1), comply with the request.
 Note that a source indication of 0 (unspecified) or 2 (pager) are always
 obeyed.
+.It ACTIVE_WS
+Ensure new newly launched windows open on the active workspace,
+instead of using the workspace of any existing windows sharing the same process ID.
 .El
 .Pp
 Custom quirks in the configuration file are specified as follows:

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -671,6 +671,7 @@ struct quirk {
 #define SWM_Q_NOFOCUSONMAP	(1<<6)	/* Don't focus on window when mapped. */
 #define SWM_Q_FOCUSONMAP_SINGLE	(1<<7)	/* Only focus if single win of type. */
 #define SWM_Q_OBEYAPPFOCUSREQ	(1<<8)	/* Focus when applications ask. */
+#define SWM_Q_ACTIVE_WS		(1<<9)	/* Always make new window in active ws. */
 };
 TAILQ_HEAD(quirk_list, quirk);
 struct quirk_list		quirks = TAILQ_HEAD_INITIALIZER(quirks);
@@ -7550,6 +7551,7 @@ const char *quirkname[] = {
 	"NOFOCUSONMAP",
 	"FOCUSONMAP_SINGLE",
 	"OBEYAPPFOCUSREQ",
+	"ACTIVE_WS",
 };
 
 /* SWM_Q_WS: retain '|' for back compat for now (2009-08-11) */
@@ -8794,7 +8796,9 @@ manage_window(xcb_window_t id, int mapped)
 	get_wm_protocols(win);
 
 	/* Figure out which workspace the window belongs to. */
-	if ((p = find_pid(window_get_pid(win->id))) != NULL) {
+	if (!(win->quirks & SWM_Q_ACTIVE_WS) &&
+	    (p = find_pid(window_get_pid(win->id))) != NULL)
+	{
 		win->ws = &r->s->ws[p->ws];
 		TAILQ_REMOVE(&pidlist, p, entry);
 		free(p);


### PR DESCRIPTION
(ignoring the PID matching existing windows)

This helps to address issue:

https://github.com/conformal/spectrwm/issues/11

NOTE: 
This is an especially common annoyance for gnome-terminal, roxterm, and any terminal that shares a process by default.
