### PR TITLE
Fix bug which causes bar text to flicker every 20 seconds.

### DIFF
--- a/baraction.sh
+++ b/baraction.sh
@@ -92,7 +92,7 @@ while :; do
 		if [ $(( ${I} % 1 )) -eq 0 ]; then
 			APM_DATA=`/usr/sbin/apm -alb`
 		fi
-		if [ $I -gt 2 ]; then
+		if [ $I -ge 2 ]; then
 			# print_date
 			print_mem $MEM
 			print_cpu $REPLY
@@ -100,6 +100,6 @@ while :; do
 			print_apm $APM_DATA
 			echo ""
 		fi
-		I=$(( ${I} + 1 ));
+		I=$(( ( ${I} + 1 ) % 22 ));
 	done
 done


### PR DESCRIPTION
OpenBSD's iostat(8) re-prints headers every 20 lines:

```
    for (hdrcnt = 1;;) {
        if (!--hdrcnt || wantheader) {
            header();
            hdrcnt = 20;
            wantheader = 0;
        }
        ... display the stats ...
    }
```

Which causes output that looks like this:

```
  0  0  2  0 98
  1  0  2  0 97
            cpu
 us ni sy in id
  0  0  2  0 98
  0  0  1  0 99
```

The parsing code didn't handle this properly, leading to output that
periodically looks like this:

```
Free mem: 6707M  CPU:   1% User   0% Nice   3% Sys   0% Int  96% Idle  CPU speed: 800 MHz  on AC: (battery 100%)
Free mem: 6707M  CPU:   1% User   0% Nice   3% Sys   0% Int  96% Idle  CPU speed: 800 MHz  on AC: (battery 100%)
Free mem: 6707M  CPU: cpu% User    % Nice    % Sys    % Int    % Idle  CPU speed: 800 MHz  on AC: (battery 100%)
Free mem: 6707M  CPU:  us% User  ni% Nice  sy% Sys  in% Int  id% Idle  CPU speed: 800 MHz  on AC: (battery 100%)
Free mem: 6707M  CPU:   1% User   0% Nice   2% Sys   0% Int  97% Idle  CPU speed: 800 MHz  on AC: (battery 100%)
Free mem: 6707M  CPU:   1% User   0% Nice   6% Sys   0% Int  93% Idle  CPU speed: 800 MHz  on AC: (battery 100%)
```

Since the headers and the expected 21st numeric data line are printed in quick
succession, the bar is rapidly updated to different lengths of text, which
looks odd, and is distracting.

This also fixes a bug where the first valid line of statistics was ignored,
because the intent was to ignore the first two lines (the headers), but the
counter started at 0, was postincrement, and the test was -ge 2, meaning the
first 3 lines were ignored instead.
