### PR TITLE
Make xlock optional.

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -518,16 +518,16 @@ by installing the program, modifying the program call or disabling the program
 by freeing the respective key binding.
 .Pp
 For example, to override
-.Ic lock :
+.Ic term :
 .Bd -literal -offset indent
-program[lock] = xscreensaver\-command \-\-lock
+program[term] = rxvt
 .Ed
 .Pp
 To unbind
-.Ic lock
+.Ic term
 and prevent it from being validated:
 .Bd -literal -offset indent
-bind[] = MOD+Shift+Delete
+bind[] = MOD+Shift+Return
 .Ed
 .Sh BINDINGS
 .Nm

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -7063,8 +7063,6 @@ validate_spawns(void)
 void
 setup_spawn(void)
 {
-	setconfspawn("lock",		"xlock",		0);
-
 	setconfspawn("term",		"xterm",		0);
 	setconfspawn("spawn_term",	"xterm",		0);
 
@@ -7095,6 +7093,7 @@ setup_spawn(void)
 					" -sf $bar_color",	0);
 
 	 /* These are not verified for existence, even with a binding set. */
+	setconfspawn("lock",		"xlock",		SWM_SPAWN_OPTIONAL);
 	setconfspawn("screenshot_all",	"screenshot.sh full",	SWM_SPAWN_OPTIONAL);
 	setconfspawn("screenshot_wind",	"screenshot.sh window",	SWM_SPAWN_OPTIONAL);
 	setconfspawn("initscr",		"initscreen.sh",	SWM_SPAWN_OPTIONAL);

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -83,19 +83,18 @@
 # PROGRAMS
 
 # Validated default programs:
-# program[lock]		= xlock
 # program[term]		= xterm
 # program[menu]		= dmenu_run $dmenu_bottom -fn $bar_font -nb $bar_color -nf $bar_font_color -sb $bar_border -sf $bar_color
 
 # To disable validation of the above, free the respective binding(s):
-# bind[]		= MOD+Shift+Delete	# disable lock
-# bind[]		= MOD+Shift+Enter	# disable term
+# bind[]		= MOD+Shift+Return	# disable term
 # bind[]		= MOD+p			# disable menu
 
 # Optional default programs that will only be validated if you override:
+# program[lock]			= xlock			# optional
 # program[screenshot_all]	= screenshot.sh full	# optional
 # program[screenshot_wind]	= screenshot.sh window	# optional
-# program[initscr]	= initscreen.sh			# optional
+# program[initscr]		= initscreen.sh		# optional
 
 # EXAMPLE: Define 'firefox' action and bind to key.
 # program[firefox]	= firefox http://spectrwm.org/


### PR DESCRIPTION
Don't validate the "lock" program on startup by default, since
the user might prefer a different screen locking application and
xlock might not even be available on the system.
