### PR TITLE
Fix xscreensaver-command example.

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -520,7 +520,7 @@ by freeing the respective key binding.
 For example, to override
 .Ic lock :
 .Bd -literal -offset indent
-program[lock] = xscreensaver\-command \-\-lock
+program[lock] = xscreensaver\-command \-lock
 .Ed
 .Pp
 To unbind


### PR DESCRIPTION
xscreensaver-command's options only have one leading dash.
