### PR TITLE
Implement rg_move_prev/rg_move_next to move workspaces across regions/screens

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -629,6 +629,10 @@ ws_prior
 rg_next
 .It Cm M-S- Ns Aq Cm Left
 rg_prev
+.It Cm M-c
+rg_move_next
+.It Cm M-S-c
+rg_move_prev
 .It Cm M-s
 screenshot_all
 .It Cm M-S-s
@@ -778,6 +782,10 @@ Switch to last visited workspace.
 Switch to next region.
 .It Cm rg_prev
 Switch to previous region.
+.It Cm rg_move_next
+Switch region to next screen.
+.It Cm rg_move_prev
+Switch region to previous screen.
 .It Cm screenshot_all
 Take screenshot of entire screen (if enabled)
 (see

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -652,6 +652,8 @@ union arg {
 #define SWM_ARG_ID_LOWER	(106)
 #define SWM_ARG_ID_BAR_TOGGLE	(110)
 #define SWM_ARG_ID_BAR_TOGGLE_WS	(111)
+#define SWM_ARG_ID_CYCLERG_MOVE_UP	(112)
+#define SWM_ARG_ID_CYCLERG_MOVE_DOWN	(113)
 	char			**argv;
 };
 
@@ -882,6 +884,8 @@ enum keyfuncid {
 	KF_RG_9,
 	KF_RG_NEXT,
 	KF_RG_PREV,
+	KF_RG_MOVE_NEXT,
+	KF_RG_MOVE_PREV,
 	KF_SCREEN_NEXT,
 	KF_SCREEN_PREV,
 	KF_SEARCH_WIN,
@@ -3950,6 +3954,7 @@ focusrg(struct swm_region *r, union arg *args)
 void
 cyclerg(struct swm_region *r, union arg *args)
 {
+	union arg		a;
 	struct swm_region	*rr = NULL;
 	int			i, num_screens;
 
@@ -3963,11 +3968,13 @@ cyclerg(struct swm_region *r, union arg *args)
 
 	switch (args->id) {
 	case SWM_ARG_ID_CYCLERG_UP:
+	case SWM_ARG_ID_CYCLERG_MOVE_UP:
 		rr = TAILQ_NEXT(r, entry);
 		if (rr == NULL)
 			rr = TAILQ_FIRST(&screens[i].rl);
 		break;
 	case SWM_ARG_ID_CYCLERG_DOWN:
+	case SWM_ARG_ID_CYCLERG_MOVE_DOWN:
 		rr = TAILQ_PREV(r, swm_region_list, entry);
 		if (rr == NULL)
 			rr = TAILQ_LAST(&screens[i].rl, swm_region_list);
@@ -3978,9 +3985,22 @@ cyclerg(struct swm_region *r, union arg *args)
 	if (rr == NULL)
 		return;
 
-	focus_region(rr);
-	center_pointer(rr);
-	focus_flush();
+	switch (args->id) {
+	case SWM_ARG_ID_CYCLERG_UP:
+	case SWM_ARG_ID_CYCLERG_DOWN:
+		focus_region(rr);
+		center_pointer(rr);
+		focus_flush();
+		break;
+	case SWM_ARG_ID_CYCLERG_MOVE_UP:
+	case SWM_ARG_ID_CYCLERG_MOVE_DOWN:
+		a.id = rr->ws->idx;
+		switchws(r, &a);
+		break;
+	default:
+		return;
+	};
+
 	DNPRINTF(SWM_D_FOCUS, "cyclerg: done\n");
 }
 
@@ -6605,6 +6625,8 @@ struct keyfunc {
 	{ "rg_9",		focusrg,	{.id = 8} },
 	{ "rg_next",		cyclerg,	{.id = SWM_ARG_ID_CYCLERG_UP} },
 	{ "rg_prev",		cyclerg,	{.id = SWM_ARG_ID_CYCLERG_DOWN} },
+	{ "rg_move_next",	cyclerg,	{.id = SWM_ARG_ID_CYCLERG_MOVE_UP} },
+	{ "rg_move_prev",	cyclerg,	{.id = SWM_ARG_ID_CYCLERG_MOVE_DOWN} },
 	{ "screen_next",	cyclerg,	{.id = SWM_ARG_ID_CYCLERG_UP} },
 	{ "screen_prev",	cyclerg,	{.id = SWM_ARG_ID_CYCLERG_DOWN} },
 	{ "search_win",		search_win,	{0} },
@@ -7376,6 +7398,8 @@ setup_keys(void)
 	setkeybinding(MODKEY,		XK_KP_Up,	KF_RG_8,	NULL);
 	setkeybinding(MODKEY,		XK_KP_Prior,	KF_RG_9,	NULL);
 	setkeybinding(MODKEY_SHIFT,	XK_Right,	KF_RG_NEXT,	NULL);
+	setkeybinding(MODKEY,		XK_c,		KF_RG_MOVE_NEXT,NULL);
+	setkeybinding(MODKEY_SHIFT,	XK_c,		KF_RG_MOVE_PREV,NULL);
 	setkeybinding(MODKEY_SHIFT,	XK_Left,	KF_RG_PREV,	NULL);
 	setkeybinding(MODKEY,		XK_f,		KF_SEARCH_WIN,	NULL);
 	setkeybinding(MODKEY,		XK_slash,	KF_SEARCH_WORKSPACE,NULL);


### PR DESCRIPTION
adds rg_move_next (M-c for "cycle") and rg_move_prev (M-S-c).

It's a convenience function to move a workspace to the next/previous
screen, having the effect of swapping screen contents with the
next/previous screen.

It simply reuses switchws() to do the work.

I was tired of hunting down the workspace number of the screen.

Looks like an alternate implementation of #66.
Existing "discussion": http://thread.gmane.org/gmane.comp.window-managers.spectrwm/37