### PR TITLE
Implement stack_balance and assign it to M-S-<h,l>

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -316,6 +316,7 @@ See
 .Ic master_del ,
 .Ic stack_inc ,
 .Ic stack_dec ,
+.Ic stack_balance ,
 and
 .Ic always_raise
 for more information.
@@ -563,6 +564,8 @@ cycle_layout
 flip_layout
 .It Cm M-S- Ns Aq Cm Space
 stack_reset
+.It Cm M-S-h
+stack_balance
 .It Cm M-h
 master_shrink
 .It Cm M-l
@@ -700,6 +703,8 @@ Cycle layout.
 Swap the master and stacking areas.
 .It Cm stack_reset
 Reset layout.
+.It Cm stack_balance
+Balance master/stacking area.
 .It Cm master_shrink
 Shrink master area.
 .It Cm master_grow

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -624,6 +624,7 @@ union arg {
 #define SWM_ARG_ID_FLIPLAYOUT	(24)
 #define SWM_ARG_ID_STACKRESET	(30)
 #define SWM_ARG_ID_STACKINIT	(31)
+#define SWM_ARG_ID_STACKBALANCE	(32)
 #define SWM_ARG_ID_CYCLEWS_UP	(40)
 #define SWM_ARG_ID_CYCLEWS_DOWN	(41)
 #define SWM_ARG_ID_CYCLERG_UP	(42)
@@ -890,6 +891,7 @@ enum keyfuncid {
 	KF_STACK_INC,
 	KF_STACK_DEC,
 	KF_STACK_RESET,
+	KF_STACK_BALANCE,
 	KF_SWAP_MAIN,
 	KF_SWAP_NEXT,
 	KF_SWAP_PREV,
@@ -4853,6 +4855,9 @@ vertical_config(struct workspace *ws, int id)
 		ws->l_state.vertical_mwin = 1;
 		ws->l_state.vertical_stacks = 1;
 		break;
+	case SWM_ARG_ID_STACKBALANCE:
+		ws->l_state.vertical_msize = SWM_V_SLICE / (ws->l_state.vertical_stacks + 1);
+		break;
 	case SWM_ARG_ID_MASTERSHRINK:
 		if (ws->l_state.vertical_msize > 1)
 			ws->l_state.vertical_msize--;
@@ -4902,6 +4907,9 @@ horizontal_config(struct workspace *ws, int id)
 		ws->l_state.horizontal_mwin = 1;
 		ws->l_state.horizontal_msize = SWM_H_SLICE / 2;
 		ws->l_state.horizontal_stacks = 1;
+		break;
+	case SWM_ARG_ID_STACKBALANCE:
+		ws->l_state.horizontal_msize = SWM_H_SLICE / (ws->l_state.horizontal_stacks + 1);
 		break;
 	case SWM_ARG_ID_MASTERSHRINK:
 		if (ws->l_state.horizontal_msize > 1)
@@ -6613,6 +6621,7 @@ struct keyfunc {
 	{ "stack_inc",		stack_config,	{.id = SWM_ARG_ID_STACKINC} },
 	{ "stack_dec",		stack_config,	{.id = SWM_ARG_ID_STACKDEC} },
 	{ "stack_reset",	stack_config,	{.id = SWM_ARG_ID_STACKRESET} },
+	{ "stack_balance",	stack_config,	{.id = SWM_ARG_ID_STACKBALANCE} },
 	{ "swap_main",		swapwin,	{.id = SWM_ARG_ID_SWAPMAIN} },
 	{ "swap_next",		swapwin,	{.id = SWM_ARG_ID_SWAPNEXT} },
 	{ "swap_prev",		swapwin,	{.id = SWM_ARG_ID_SWAPPREV} },
@@ -7388,6 +7397,7 @@ setup_keys(void)
 	setkeybinding(MODKEY_SHIFT,	XK_comma,	KF_STACK_INC,	NULL);
 	setkeybinding(MODKEY_SHIFT,	XK_period,	KF_STACK_DEC,	NULL);
 	setkeybinding(MODKEY_SHIFT,	XK_space,	KF_STACK_RESET,	NULL);
+	setkeybinding(MODKEY_SHIFT,	XK_h,		KF_STACK_BALANCE, NULL);
 	setkeybinding(MODKEY,		XK_Return,	KF_SWAP_MAIN,	NULL);
 	setkeybinding(MODKEY_SHIFT,	XK_j,		KF_SWAP_NEXT,	NULL);
 	setkeybinding(MODKEY_SHIFT,	XK_k,		KF_SWAP_PREV,	NULL);


### PR DESCRIPTION
Adds "stack_balance", bound to M-S-h, which balances the current tile
layout in order to have equal-sized tiles.
