### PR TITLE
Add 'maximize_hide_bar' to also hide the bar when maximing a window.

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -283,6 +283,11 @@ and changes to layout.
 .It Ar manual
 Set window focus on window interaction only.
 .El
+.It Ic maximize_hide_bar
+When set to 1,
+.Ic maximize_toggle
+will also hide/restore the bar visibility of the affected workspace.
+Defaults to 0.
 .It Ic java_workaround
 Workaround a Java GUI rendering issue on non-reparenting window managers by
 impersonating the LG3D window manager, written by Sun. Default is 1.

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -401,6 +401,7 @@ char		 *bar_format = NULL;
 bool		 stack_enabled = true;
 bool		 clock_enabled = true;
 bool		 iconic_enabled = false;
+bool		 maximize_hide_bar = false;
 bool		 urgent_enabled = false;
 bool		 urgent_collapse = false;
 char		*clock_format = NULL;
@@ -4558,7 +4559,7 @@ update_floater(struct ws_win *win)
 
 		win->g = r->g;
 
-		if (bar_enabled && ws->bar_enabled) {
+		if (bar_enabled && ws->bar_enabled && !maximize_hide_bar) {
 			if (!bar_at_bottom)
 				Y(win) += bar_height;
 			HEIGHT(win) -= bar_height;
@@ -7900,6 +7901,7 @@ enum {
 	SWM_S_FOCUS_MODE,
 	SWM_S_ICONIC_ENABLED,
 	SWM_S_JAVA_WORKAROUND,
+	SWM_S_MAXIMIZE_HIDE_BAR,
 	SWM_S_REGION_PADDING,
 	SWM_S_SPAWN_ORDER,
 	SWM_S_SPAWN_TERM,
@@ -8072,6 +8074,9 @@ setconfvalue(const char *selector, const char *value, int flags)
 		break;
 	case SWM_S_JAVA_WORKAROUND:
 		java_workaround = (atoi(value) != 0);
+		break;
+	case SWM_S_MAXIMIZE_HIDE_BAR:
+		maximize_hide_bar = atoi(value);
 		break;
 	case SWM_S_REGION_PADDING:
 		region_padding = atoi(value);
@@ -8444,6 +8449,7 @@ struct config_option configopt[] = {
 	{ "focus_mode",			setconfvalue,	SWM_S_FOCUS_MODE },
 	{ "iconic_enabled",		setconfvalue,	SWM_S_ICONIC_ENABLED },
 	{ "java_workaround",		setconfvalue,	SWM_S_JAVA_WORKAROUND },
+	{ "maximize_hide_bar",		setconfvalue,	SWM_S_MAXIMIZE_HIDE_BAR },
 	{ "keyboard_mapping",		setkeymapping,	0 },
 	{ "layout",			setlayout,	0 },
 	{ "modkey",			setconfmodkey,	0 },

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -43,6 +43,7 @@
 # clock_enabled		= 1
 # clock_format		= %a %b %d %R %Z %Y
 # iconic_enabled	= 0
+# maximize_hide_bar	= 0
 # window_class_enabled	= 0
 # window_instance_enabled	= 0
 # window_name_enabled	= 0


### PR DESCRIPTION
Adds a new variable "maximize_hide_bar". When set to 1, and a window
is maximized, the bar is also automatically hidden.