### PR TITLE
Implement quirk NOFOCUSCYCLE to remove a window from the normal focus cycle

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -959,6 +959,9 @@ Remove border to allow window to use full region size.
 .It FOCUSPREV
 On exit force focus on previously focused application not previous
 application in the stack.
+.It NOFOCUSCYCLE
+Remove from normal focus cycle (focus_prev or focus_next). The window can
+still be focused using search_win.
 .It NOFOCUSONMAP
 Don't change focus to the window when it first appears on the screen.
 Has no effect when

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -677,6 +677,7 @@ struct quirk {
 #define SWM_Q_OBEYAPPFOCUSREQ	(1<<8)	/* Focus when applications ask. */
 #define SWM_Q_IGNOREPID		(1<<9)	/* Ignore PID when determining ws. */
 #define SWM_Q_IGNORESPAWNWS	(1<<10)	/* Ignore _SWM_WS when managing win. */
+#define SWM_Q_NOFOCUSCYCLE	(1<<11)	/* Remove from normal focus cycle. */
 };
 TAILQ_HEAD(quirk_list, quirk);
 struct quirk_list		quirks = TAILQ_HEAD_INITIALIZER(quirks);
@@ -4303,7 +4304,8 @@ focus(struct swm_region *r, union arg *args)
 		} while (winfocus && (ICONIC(winfocus) ||
 		    winfocus->id == cur_focus->transient ||
 		    (cur_focus->transient != XCB_WINDOW_NONE &&
-		    winfocus->transient == cur_focus->transient)));
+		    winfocus->transient == cur_focus->transient) ||
+		    (winfocus->quirks & SWM_Q_NOFOCUSCYCLE)));
 		break;
 	case SWM_ARG_ID_FOCUSNEXT:
 		if (cur_focus == NULL)
@@ -4319,7 +4321,8 @@ focus(struct swm_region *r, union arg *args)
 		} while (winfocus && (ICONIC(winfocus) ||
 		    winfocus->id == cur_focus->transient ||
 		    (cur_focus->transient != XCB_WINDOW_NONE &&
-		    winfocus->transient == cur_focus->transient)));
+		    winfocus->transient == cur_focus->transient) ||
+		    (winfocus->quirks & SWM_Q_NOFOCUSCYCLE)));
 		break;
 	case SWM_ARG_ID_FOCUSMAIN:
 		if (cur_focus == NULL)
@@ -7585,6 +7588,7 @@ const char *quirkname[] = {
 	"OBEYAPPFOCUSREQ",
 	"IGNOREPID",
 	"IGNORESPAWNWS",
+	"NOFOCUSCYCLE",
 };
 
 /* SWM_Q_DELIM: retain '|' for back compat for now (2009-08-11) */


### PR DESCRIPTION
If you assign "NOFOCUSCYCLE" to a window, the normal focus_next,
focus_prev will never select it. But have no fear m'am! You can still
focus the window though search_win and the mouse.

I use it for monitoring applications and for screen-capture programs such as "screenkey" or "keymon".

Maybe a better option would be to set the _SKIP_PAGER/_SKIP_TASKBAR atoms?
Comments appreciated.