### PR TITLE
Quirk noborder

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -1050,6 +1050,8 @@ application in the stack.
 .It NOFOCUSCYCLE
 Remove from normal focus cycle (focus_prev or focus_next). The window can
 still be focused using search_win.
+.It MINIMALBORDER
+Remove border when window is unfocused and floating.
 .It NOFOCUSONMAP
 Don't change focus to the window when it first appears on the screen.
 Has no effect when


### PR DESCRIPTION
New quirk "NOBORDER", which disables the border when the window is
floating and unfocused. That is, the border disappears if the window is
not currently focused and floating, but comes back as soon the window is
focused. The border is always there if the window is tiled though.
I use it for monitoring applications, for which border is only waste
of space, and for screen-capture programs such as "screenkey" or "keymon".

I usually use this quirk together with NOFOCUSCYCLE in #78 
