### PR TITLE
Visible noswap

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -464,6 +464,12 @@ See
 and
 .Ar stack_dec
 for more information.
+.It Ic visible_noswap
+Do not swap on already visible workspace, useful on multi screen setup.
+Use
+.Ar warp_pointer
+if you want to send pointer in that region.
+Enable by setting to 1.
 .It Ic window_class_enabled
 Enable or disable displaying the window class name (from WM_CLASS) in the
 status bar.

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -332,6 +332,7 @@ int			term_width = 0;
 int			font_adjusted = 0;
 unsigned int		mod_key = MODKEY;
 bool			warp_pointer = false;
+bool			visible_noswap = false;
 
 /* dmenu search */
 struct swm_region	*search_r;
@@ -3804,6 +3805,11 @@ switchws(struct swm_region *r, union arg *args)
 		old_ws->r = NULL;
 		unmap_old = true;
 	} else {
+		if (visible_noswap) {
+			center_pointer(other_r);
+			return;
+		}
+
 		/* the other ws is visible in another region, exchange them */
 		other_r->ws_prior = new_ws;
 		other_r->ws = old_ws;
@@ -7920,6 +7926,7 @@ enum {
 	SWM_S_URGENT_COLLAPSE,
 	SWM_S_URGENT_ENABLED,
 	SWM_S_VERBOSE_LAYOUT,
+	SWM_S_VISIBLE_NOSWAP,
 	SWM_S_WARP_POINTER,
 	SWM_S_WINDOW_CLASS_ENABLED,
 	SWM_S_WINDOW_INSTANCE_ENABLED,
@@ -8134,6 +8141,9 @@ setconfvalue(const char *selector, const char *value, int flags)
 			else
 				layouts[i].l_string = plain_stacker;
 		}
+		break;
+	case SWM_S_VISIBLE_NOSWAP:
+		visible_noswap = (atoi(value) != 0);
 		break;
 	case SWM_S_WARP_POINTER:
 		warp_pointer = (atoi(value) != 0);
@@ -8472,6 +8482,7 @@ struct config_option configopt[] = {
 	{ "urgent_collapse",		setconfvalue,	SWM_S_URGENT_COLLAPSE },
 	{ "urgent_enabled",		setconfvalue,	SWM_S_URGENT_ENABLED },
 	{ "verbose_layout",		setconfvalue,	SWM_S_VERBOSE_LAYOUT },
+	{ "visible_noswap",		setconfvalue,	SWM_S_VISIBLE_NOSWAP },
 	{ "warp_pointer",		setconfvalue,	SWM_S_WARP_POINTER },
 	{ "window_class_enabled",	setconfvalue,	SWM_S_WINDOW_CLASS_ENABLED },
 	{ "window_instance_enabled",	setconfvalue,	SWM_S_WINDOW_INSTANCE_ENABLED },

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -8,6 +8,7 @@
 # focus_close_wrap	= 1
 # focus_default		= last
 # spawn_position		= next
+# visible_noswap	= 1
 # warp_pointer		= 1
 
 # Window Decoration


### PR DESCRIPTION
Add a new visible_noswap option that allow to not swap two visible workspace

This is useful in multiple monitor setup, if you have workspace 1 on left
and workspace 2 on right monitor, trying to switch from 1 to 2 on left
region now does nothing.

This option can be enabled in combination with warp_pointer to send the
mouse pointer on the non-swapped workspace.