### PR TITLE
Fixed bug in man page.

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -667,11 +667,11 @@ ws_next_all
 .It Cm M- Ns Aq Cm Down
 ws_prev_all
 .It Cm M-a
-ws_next_move
+ws_prior
 .It Cm M-S- Ns Aq Cm Left
 ws_prev_move
 .It Cm M-S- Ns Aq Cm Up
-ws_prior
+ws_next_move
 .It Cm M-S- Ns Aq Cm Right
 rg_next
 .It Cm M-S- Ns Aq Cm Left


### PR DESCRIPTION
It was saying M-S-\<Up> switches to the last visited workspace, but by default it is M-a.