### PR TITLE
Mouse button mapping config option, by levaidaniel

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -363,6 +363,12 @@ This setting is not retained at restart.
 .It Ic modkey
 Change mod key.
 Mod1 is generally the ALT key and Mod4 is the windows key on a PC.
+.It Ic move_button
+Change mouse button used for moving windows.
+But1 is the left, But2 is the middle and But3 is the right mouse button.
+.It Ic resize_button
+Change mouse button used for resizing windows.
+But1 is the left, But2 is the middle and But3 is the right mouse button.
 .It Ic name
 Set the name of a workspace at start-of-day.
 Defined in the format

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -333,6 +333,8 @@ int			term_width = 0;
 int			font_adjusted = 0;
 unsigned int		mod_key = MODKEY;
 bool			warp_pointer = false;
+unsigned int		mouse_button_move = XCB_BUTTON_INDEX_1;
+unsigned int		mouse_button_resize = XCB_BUTTON_INDEX_3;
 
 /* dmenu search */
 struct swm_region	*search_r;
@@ -1119,6 +1121,8 @@ int	 setautorun(const char *, const char *, int);
 int	 setconfbinding(const char *, const char *, int);
 int	 setconfcolor(const char *, const char *, int);
 int	 setconfmodkey(const char *, const char *, int);
+int	 setconfmousebuttonmove(const char *, const char *, int);
+int	 setconfmousebuttonresize(const char *, const char *, int);
 int	 setconfquirk(const char *, const char *, int);
 int	 setconfregion(const char *, const char *, int);
 int	 setconfspawn(const char *, const char *, int);
@@ -1166,6 +1170,7 @@ void	 unmap_window(struct ws_win *);
 void	 updatenumlockmask(void);
 void	 update_floater(struct ws_win *);
 void	 update_modkey(unsigned int);
+unsigned char	update_mousebutton(unsigned char, unsigned int);
 void	 update_win_stacking(struct ws_win *);
 void	 update_window(struct ws_win *);
 void	 update_window_color(struct ws_win *);
@@ -6798,6 +6803,31 @@ update_modkey(unsigned int mod)
 			buttons[i].mask = mod;
 }
 
+unsigned char
+update_mousebutton(unsigned char type, unsigned int but)
+{
+	int			i;
+
+	switch (type) {
+		case 0:
+			mouse_button_move = but;
+			break;
+		case 1:
+			mouse_button_resize = but;
+			break;
+	}
+
+	for (i = 0; i < LENGTH(buttons); i++) {
+		if (buttons[i].func == move)
+			buttons[i].button = mouse_button_move;
+
+		if (buttons[i].func == resize)
+			buttons[i].button = mouse_button_resize;
+	}
+
+	return(1);
+}
+
 int
 spawn_expand(struct swm_region *r, union arg *args, const char *spawn_name,
     char ***ret_args)
@@ -8290,6 +8320,48 @@ setconfmodkey(const char *selector, const char *value, int flags)
 }
 
 int
+setconfmousebuttonmove(const char *selector, const char *value, int flags)
+{
+	/* suppress unused warnings since vars are needed */
+	(void)selector;
+	(void)flags;
+
+	if (strncasecmp(value, "But1", strlen("But1")) == 0) {
+		if (!update_mousebutton(0, XCB_BUTTON_INDEX_1))
+			return (1);
+	} else if (strncasecmp(value, "But2", strlen("But2")) == 0) {
+		if (!update_mousebutton(0, XCB_BUTTON_INDEX_2))
+			return (1);
+	} else if (strncasecmp(value, "But3", strlen("But3")) == 0) {
+		if (!update_mousebutton(0, XCB_BUTTON_INDEX_3))
+			return (1);
+	} else
+		return (1);
+	return (0);
+}
+
+int
+setconfmousebuttonresize(const char *selector, const char *value, int flags)
+{
+	/* suppress unused warnings since vars are needed */
+	(void)selector;
+	(void)flags;
+
+	if (strncasecmp(value, "But1", strlen("But1")) == 0) {
+		if (!update_mousebutton(1, XCB_BUTTON_INDEX_1))
+			return (1);
+	} else if (strncasecmp(value, "But2", strlen("But2")) == 0) {
+		if (!update_mousebutton(1, XCB_BUTTON_INDEX_2))
+			return (1);
+	} else if (strncasecmp(value, "But3", strlen("But3")) == 0) {
+		if (!update_mousebutton(1, XCB_BUTTON_INDEX_3))
+			return (1);
+	} else
+		return (1);
+	return (0);
+}
+
+int
 setconfcolor(const char *selector, const char *value, int flags)
 {
 	int	first, last, i = 0, num_screens;
@@ -8537,6 +8609,8 @@ struct config_option configopt[] = {
 	{ "keyboard_mapping",		setkeymapping,	0 },
 	{ "layout",			setlayout,	0 },
 	{ "modkey",			setconfmodkey,	0 },
+	{ "move_button",		setconfmousebuttonmove, 0 },
+	{ "resize_button",		setconfmousebuttonresize, 0 },
 	{ "program",			setconfspawn,	0 },
 	{ "quirk",			setconfquirk,	0 },
 	{ "region",			setconfregion,	0 },
@@ -8702,6 +8776,12 @@ conf_load(const char *filename, int keymapping)
 	if (line)
 		free(line);
 	fclose(config);
+
+	if (mouse_button_move == mouse_button_resize) {
+		add_startup_exception("%s: move and resize mouse buttons match",
+		    filename);
+	}
+
 	DNPRINTF(SWM_D_CONF, "conf_load: end\n");
 
 	return (0);


### PR DESCRIPTION
With modification not to enforce correct buttons when applying configuration.
Instead warn if an invalid configuration is set after loading the configuration.