### PR TITLE
Add a workspace list to the bar

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -202,6 +202,7 @@ It may contain the following character sequences:
 .It Li "+D" Ta "Workspace name"
 .It Li "+F" Ta "Floating indicator"
 .It Li "+I" Ta "Workspace index"
+.It Li "+L" Ta "List of active workspaces on this screen"
 .It Li "+M" Ta "Number of iconic (minimized) windows in workspace"
 .It Li "+N" Ta "Screen number"
 .It Li "+P" Ta "Window class and instance separated by a colon"
@@ -230,6 +231,32 @@ static format.
 See the
 .Ic bar_format
 option for more details.
+.It Ic bar_ws_list_show
+When the bar workspace list is enabled, define which set of workspaces
+should be displayed.
+Possible values are
+.Ar active ,
+.Ar named ,
+and
+.Ar all ,
+where each is a superset of the previous one.
+.Pp
+Workspaces are in the
+.Ar active
+set if they either contain windows or are associated with the current
+region (the default).
+The
+.Ar named
+set contains all those considered
+.Ar active ,
+plus any that are named (regardless of whether they contain windows).
+Finally,
+.Ar all
+will simply display all workspaces associated with this screen.
+.It Ic bar_ws_list_urgent
+When the bar workspace list is enabled, whether to display an urgency
+hint (!) next to workspaces with an urgent window.
+Enable by setting to 1 (the default is 0, off).
 .It Ic bind Ns Bq Ar x
 Bind key or button combo to action
 .Ar x .

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -40,6 +40,8 @@
 # bar_action		= baraction.sh
 # bar_justify		= left
 # bar_format		= +N:+I +S <+D>+4<%a %b %d %R %Z %Y+8<+A+4<+V
+# bar_ws_list_show	= active
+# bar_ws_list_urgent	= 0
 # bar_at_bottom		= 1
 # stack_enabled		= 1
 # clock_enabled		= 1


### PR DESCRIPTION
By adding '+L' to the `bar_format`, you can now get a list of active
workspaces associated with the current screen (where active is defined
as either (a) containing windows or (b) being associated with the
current region, regardless of whether windows are present).

Two '*' characters bracketing a workspace indicates it is the workspace
of the current region.

For example, suppose we have windows on workspaces 1 and 5, and we are
currently on workspace 4. Further, suppose workspace 1 is called "web".
Then, the list would look like: `[ 1:web *4* 5 ]`

This is implemented in `bar_workspace_list` in spectrwm.c.
