### PR TITLE
Added a config option to spawn programs on the current workspace.

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -413,6 +413,14 @@ and
 and
 .Ar previous
 are relative to the focused window.
+.It Ic spawn_on_current_workspace
+Spawn new windows of a running program on the current workspace instead the
+workspace the program was originally started on.
+Possible values are:
+.Ar 1 
+- spawn on current,
+.Ar 0 
+(default) - spawn on original.
 .It Ic stack_enabled
 Enable or disable displaying the current stacking algorithm in the status
 bar.

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -444,6 +444,7 @@ XftColor	 bar_font_color;
 XftColor	 search_font_color;
 char		*startup_exception = NULL;
 unsigned int	 nr_exceptions = 0;
+bool spawn_on_current = false;
 
 /* layout manager data */
 struct swm_geometry {
@@ -3499,7 +3500,14 @@ spawn(int ws_idx, union arg *args, bool close_fd)
 		warn("spawn: asprintf SWM_WS");
 		_exit(1);
 	}
-	setenv("_SWM_WS", ret, 1);
+
+	// Unsetting _SWM_WS leads to windows always being 
+	// spawned on the current workspace.
+	if (!spawn_on_current)
+		setenv("_SWM_WS", ret, 1);
+	else
+		unsetenv("_SWM_WS");
+
 	free(ret);
 	ret = NULL;
 
@@ -8442,6 +8450,7 @@ enum {
 	SWM_S_WORKSPACE_CLAMP,
 	SWM_S_WORKSPACE_LIMIT,
 	SWM_S_WORKSPACE_NAME,
+	SWM_S_SPAWN_ON_CURRENT,
 };
 
 int
@@ -8706,6 +8715,9 @@ setconfvalue(const char *selector, const char *value, int flags)
 				ewmh_get_desktop_names();
 			}
 		}
+		break;
+	case SWM_S_SPAWN_ON_CURRENT:
+		spawn_on_current = (atoi(value) != 0);
 		break;
 	default:
 		return (1);
@@ -9008,6 +9020,7 @@ struct config_option configopt[] = {
 	{ "workspace_clamp",		setconfvalue,	SWM_S_WORKSPACE_CLAMP },
 	{ "workspace_limit",		setconfvalue,	SWM_S_WORKSPACE_LIMIT },
 	{ "name",			setconfvalue,	SWM_S_WORKSPACE_NAME },
+	{ "spawn_on_current_workspace", setconfvalue, SWM_S_SPAWN_ON_CURRENT }
 };
 
 void

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -11,6 +11,7 @@
 # workspace_clamp	= 1
 # warp_focus		= 1
 # warp_pointer		= 1
+# spawn_on_current_workspace = 1
 
 # Window Decoration
 # border_width		= 1


### PR DESCRIPTION
This is a suggested fix for issue #112 Moving terminal to new workspace 
causing launching to open in previous workspace.

If a programme was started and then new instances of that programme
was started while the original was still running the new instance would
end up in the original workspace.

By adding a new configuration option that unsets the environment
variable "_SWM_WS" the behaviour is changed to spawn new windows on
the workspace that is currently in focus.

The main idea for the fix came from forum post #3, by the member
"br", at https://opensource.conformal.com/fluxbb/viewtopic.php?pid=2569.
Other users in that thread claim to have been using the code change without
problems and I have not noticed any side-effects.