### PR TITLE
Implement the "raise_focused" function

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -714,6 +714,8 @@ iconify
 uniconify
 .It Cm M-e
 maximize_toggle
+.It Cm Aq Ar unbound
+raise_focused
 .It Cm M-S-r
 always_raise
 .It Cm M-v
@@ -894,6 +896,8 @@ Restore (map) window returned by
 selection.
 .It Cm maximize_toggle
 Toggle maximization of focused window.
+.It Cm raise_focused
+Raise the current window.
 .It Cm always_raise
 When set tiled windows are allowed to obscure floating windows.
 .It Cm button2


### PR DESCRIPTION
I fetched a couple of days ago, and to my surprise much of my patches went in, so I'll propose also this one which has been sitting in my repo for years.

It adds a "raise_focused" function (unbound by default). I rarely use always_raise. I generally prefer to handle stacking manually. For this reason, when cycling through floating windows, you sometimes need to raise the window manually. There's an EHWM command to call raise_window, so I'm surprised we didn't have a bindable function for it.

raise_focused does just that, so nothing special.

There's something extra though. If the window is currently stacked, we *also* raise it above any other window as well. This is logical, as it mimics what always_raise does. As soon as the window loses focus, we restore the original stacking order, so that everything returns back to normal.