### PR TITLE
Always swap regions when using rg_move_next/rg_move_prev

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -4208,8 +4208,6 @@ switchws(struct binding *bp, struct swm_region *r, union arg *args)
 	int			wsid = args->id;
 	bool			unmap_old = false;
 
-	(void)bp;
-
 	if (!(r && r->s))
 		return;
 
@@ -4229,7 +4227,8 @@ switchws(struct binding *bp, struct swm_region *r, union arg *args)
 		return;
 
 	other_r = new_ws->r;
-	if (other_r && workspace_clamp) {
+	if (other_r && workspace_clamp &&
+	    bp->action != FN_RG_MOVE_NEXT && bp->action != FN_RG_MOVE_PREV) {
 		DNPRINTF(SWM_D_WS, "switchws: ws clamped.\n");
 
 		if (warp_focus) {


### PR DESCRIPTION
rg_move_next/prev are always supposed to _move_ the region, even when combined with workspace_clamp (which I just discovered today).