### PR TITLE
Fix man errors

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -602,7 +602,7 @@ provides many functions (or actions) accessed via key or pointer bindings.
 The default bindings are listed below:
 .Pp
 .Bl -tag -width "M-j, M-<TAB>XXXXXX" -offset indent -compact
-.It Cm Ns Aq Cm Button1
+.It Aq Cm Button1
 focus
 .It Cm M- Ns Aq Cm Button1
 move
@@ -624,7 +624,7 @@ cycle_layout
 flip_layout
 .It Cm M-S- Ns Aq Cm Space
 stack_reset
-.It Cm Aq Ar unbound
+.It Aq Ar unbound
 stack_balance
 .It Cm M-h
 master_shrink
@@ -674,9 +674,9 @@ wind_kill
 .Pf rg_ Aq Ar 1-9
 .It Cm M-S- Ns Aq Ar Keypad 1-9
 .Pf mvrg_ Aq Ar 1-9
-.It Cm Aq Ar unbound
+.It Aq Ar unbound
 mvrg_next
-.It Cm Aq Ar unbound
+.It Aq Ar unbound
 mvrg_prev
 .It Cm M- Ns Aq Cm Right
 ws_next
@@ -696,9 +696,9 @@ ws_next_move
 rg_next
 .It Cm M-S- Ns Aq Cm Left
 rg_prev
-.It Cm Aq Ar unbound
+.It Aq Ar unbound
 rg_move_next
-.It Cm Aq Ar unbound
+.It Aq Ar unbound
 rg_move_prev
 .It Cm M-s
 screenshot_all
@@ -987,7 +987,7 @@ In the above example,
 initiates
 .Ic move
 and
-.Cm Aq Cm Button3
+.Aq Cm Button3
 pressed with any other combination of modifiers
 sets focus to the window/region under the pointer.
 .Pp
@@ -998,7 +998,7 @@ bind[focus] = REPLAY+Button3
 .Ed
 .Pp
 In the above example, when
-.Cm Aq Cm Button3
+.Aq Cm Button3
 is pressed without any modifier(s), focus is set to the window under the
 pointer and the button press is passed to the window.
 .Pp


### PR DESCRIPTION
Lintian reports the following:

    W: spectrwm: manpage-has-errors-from-man
    usr/share/man/man1/spectrwm.1.gz
    Using a macro as first argument cancels effect of .Cm (#605)

Remove all uses of the `.Cm` macro that are immediately followed by another macro, such as `.Ns` or `.Aq`.

More information about the Lintian error, including how to check a man page for similar errors without having to use Lintian, are available at https://lintian.debian.org/tags/manpage-has-errors-from-man.html