### PR TITLE
Include the top level header of each xcb module used

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -69,11 +69,10 @@
 #include <X11/Xcursor/Xcursor.h>
 #include <X11/Xft/Xft.h>
 #include <X11/Xlib-xcb.h>
-#include <xcb/xcb_atom.h>
-#include <xcb/xcb_aux.h>
-#include <xcb/xcb_event.h>
+#include <xcb/xcb.h>
 #include <xcb/xcb_icccm.h>
 #include <xcb/xcb_keysyms.h>
+#include <xcb/xcb_util.h>
 #include <xcb/xtest.h>
 #include <xcb/randr.h>
 


### PR DESCRIPTION
One xcb module, one header file: `<xcb/xcb.h>` should to be included directly, instead of relying on other modules dragging it in; on the other hand, it's okay to include just the top level `<xcb/xcb_util.h>` instead of the three separate sub-headers.