### PR TITLE
Support $XDG_CONFIG_HOME

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -61,9 +61,17 @@ See the
 section below for defaults and customizations.
 .Sh CONFIGURATION FILES
 .Nm
-first tries to open the user specific file,
+follows the XDG Base Directory Specification.
+If
+.Pa $XDG_CONFIG_HOME
+is set and non-empty,
+it tries to open the user specific file located at
+.Pa $XDG_CONFIG_HOME/spectrwm/spectrwm.conf .
+It falls back to
+.Pa ~/.config/spectrwm/spectrwm.conf
+and then
 .Pa ~/.spectrwm.conf .
-If that file is unavailable,
+If no user specific file is found,
 it then tries to open the global configuration file
 .Pa /etc/spectrwm.conf .
 .Pp
@@ -1308,7 +1316,11 @@ Sending
 .Nm
 a HUP signal will restart it.
 .Sh FILES
-.Bl -tag -width "/etc/spectrwm.confXXX" -compact
+.Bl -tag -width "$XDG_CONFIG_HOME/spectrwm/spectrwm.conf" -compact
+.It Pa $XDG_CONFIG_HOME/spectrwm/spectrwm.conf
+or
+.It Pa ~/.config/spectrwm/spectrwm.conf
+or
 .It Pa ~/.spectrwm.conf
 .Nm
 user specific settings.

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -12122,21 +12122,41 @@ main(int argc, char *argv[])
 		conf[0] = '\0';
 		switch (i) {
 		case 0:
+			/* $XDG_CONFIG_HOME */
+			snprintf(conf, sizeof conf, "%s/spectrwm/%s",
+			    getenv("XDG_CONFIG_HOME"), SWM_CONF_FILE);
+			break;
+		case 1:
+			/* XDG spec default ~/.config */
+			snprintf(conf, sizeof conf, "%s/.config/spectrwm/%s",
+			    pwd->pw_dir, SWM_CONF_FILE);
+			break;
+		case 2:
 			/* ~ */
 			snprintf(conf, sizeof conf, "%s/.%s",
 			    pwd->pw_dir, SWM_CONF_FILE);
 			break;
-		case 1:
+		case 3:
 			/* global */
 			snprintf(conf, sizeof conf, "/etc/%s",
 			    SWM_CONF_FILE);
 			break;
-		case 2:
+		case 4:
+			/* $XDG_CONFIG_HOME compat */
+			snprintf(conf, sizeof conf, "%s/scrotwm/%s",
+			    getenv("XDG_CONFIG_HOME"), SWM_CONF_FILE_OLD);
+			break;
+		case 5:
+			/* XDG spec default ~/.config compat */
+			snprintf(conf, sizeof conf, "%s/.config/spectrwm/%s",
+			    pwd->pw_dir, SWM_CONF_FILE_OLD);
+			break;
+		case 6:
 			/* ~ compat */
 			snprintf(conf, sizeof conf, "%s/.%s",
 			    pwd->pw_dir, SWM_CONF_FILE_OLD);
 			break;
-		case 3:
+		case 7:
 			/* global compat */
 			snprintf(conf, sizeof conf, "/etc/%s",
 			    SWM_CONF_FILE_OLD);


### PR DESCRIPTION
Look for the user specific config file at `$XDG_CONFIG_HOME/spectrwm/spectrwm.conf` before trying `$HOME/.spectrwm.conf` and `/etc/spectrwm.conf`. I tested this on Linux only, as I don't have a BSD or OSX machine.

Issue: #134