### PR TITLE
Correct size for WM_STATE

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -3039,7 +3039,7 @@ bar_cleanup(struct swm_region *r)
 void
 set_win_state(struct ws_win *win, uint8_t state)
 {
-	uint16_t		data[2] = { state, XCB_ATOM_NONE };
+	uint32_t		data[2] = { state, XCB_ATOM_NONE };
 
 	DNPRINTF(SWM_D_EVENT, "set_win_state: win %#x, state: %u\n",
 	    WINID(win), state);


### PR DESCRIPTION
Match the type of the array to the `format` argument (32).

Could change the format to 16, but the value is documented to be a `CARD32`, so may as well use 32 bit input.