### PR TITLE
Reset SIGPIPE before execvp().

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -3761,6 +3761,9 @@ spawn(int ws_idx, union arg *args, bool close_fd)
 			close(fd);
 	}
 
+	if (signal(SIGPIPE, SIG_DFL) == SIG_ERR)
+		err(1, "could not reset SIGPIPE");
+
 	execvp(args->argv[0], args->argv);
 
 	warn("spawn: execvp");


### PR DESCRIPTION
Otherwise child processes inherit SIG_IGN for SIGPIPE, which can have
unexpected consequences. e.g. when performing pkg_add -ui in an xterm
spawned by spectrwm some spurious EPIPE errors find their way to the
output due to pkg_add expecting a sane default signal environment.

<pre>
$ pkg_add -nuix vim
quirks-2.261 signed on 2016-10-11T14:06:48Z
Error from http://ftp.fr.openbsd.org/pub/OpenBSD/snapshots/packages/amd64/vim-8.0.0004-gtk2-perl-python3-ruby.tgz
signify: write to stdout: Broken pipe
Error from http://ftp.fr.openbsd.org/pub/OpenBSD/snapshots/packages/amd64/vim-8.0.0004-gtk2-lua.tgz
signify: write to stdout: Broken pipe
[...]
</pre>