### PR TITLE
add license title; format authors list for display

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,14 +1,16 @@
-Copyright (c) 2009-2016 Marco Peereboom <marco@peereboom.us>
-Copyright (c) 2009-2011 Ryan McBride <mcbride@countersiege.com>
-Copyright (c) 2009 Darrin Chandler <dwchandler@stilyagin.com>
-Copyright (c) 2009 Pierre-Yves Ritschard <pyr@spootnik.org>
-Copyright (c) 2010 Tuukka Kataja <stuge@xor.fi>
-Copyright (c) 2011 Jason L. Wright <jason@thought.net>
-Copyright (c) 2011-2016 Reginald Kennedy <rk@rejii.com>
-Copyright (c) 2011-2012 Lawrence Teo <lteo@lteo.net>
-Copyright (c) 2011-2012 Tiago Cunha <tcunha@gmx.com>
-Copyright (c) 2012-2015 David Hill <dhill@mindcry.org>
-Copyright (c) 2014-2016 Yuri D'Elia <yuri.delia@eurac.edu>
+## ISC License
+
+Copyright (c) 2009-2016 Marco Peereboom <marco@peereboom.us>,
+              2009-2011 Ryan McBride <mcbride@countersiege.com>,
+              2009 Darrin Chandler <dwchandler@stilyagin.com>,
+              2009 Pierre-Yves Ritschard <pyr@spootnik.org>,
+              2010 Tuukka Kataja <stuge@xor.fi>,
+              2011 Jason L. Wright <jason@thought.net>,
+              2011-2016 Reginald Kennedy <rk@rejii.com>,
+              2011-2012 Lawrence Teo <lteo@lteo.net>,
+              2011-2012 Tiago Cunha <tcunha@gmx.com>,
+              2012-2015 David Hill <dhill@mindcry.org>,
+              2014-2016 Yuri D'Elia <yuri.delia@eurac.edu>.
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
The line breaks don't show up properly on github because the file extension (.md) triggers the rendered view, which ignores single line breaks in the code. The result is a string of copyright notices in a single long line, without a clear separation between entries. One solution is as done here, to use a single "Copyright (c)" and split the authors list by adding commas. An alternative would be to format the notice as a bulleted list. Another is adding explicit line breaks to the source code (but that would make it less readable in plain text mode). Finally, one could simply add commas to the end of each line, but the repeated "Copyright (c)" would be redundant, since a single copyright notice can have multiple authors.

As for the license title, it's not a strict legal requirement, but it's included in pretty much every template of this license as published by [SPDX](https://spdx.org/licenses/ISC#licenseText), [OSI](https://opensource.org/licenses/ISC), [Wikipedia](https://en.wikipedia.org/wiki/ISC_license#Text), and others.