### PR TITLE
remove linebreaks to fix image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,12 @@ channel #spectrwm.
 spectrwm is ISC licensed unless otherwise specified in individual files.
 
 ## Screenshots
-![Vertical stack]
-(https://github.com/conformal/spectrwm/wiki/Scrotwm1.png)
+![Vertical stack](https://github.com/conformal/spectrwm/wiki/Scrotwm1.png)
 
-![Horizontal stack]
-(https://github.com/conformal/spectrwm/wiki/Scrotwm2.png)
+![Horizontal stack](https://github.com/conformal/spectrwm/wiki/Scrotwm2.png)
 
-![Horizontal stack]
-(https://github.com/conformal/spectrwm/wiki/Scrotwm3.png)
+![Horizontal stack](https://github.com/conformal/spectrwm/wiki/Scrotwm3.png)
 
-![Vertical stack with floater and extra window in master area]
-(https://github.com/conformal/spectrwm/wiki/Scrotwm4.png)
+![Vertical stack with floater and extra window in master area](https://github.com/conformal/spectrwm/wiki/Scrotwm4.png)
 
-![mplayer, resized and moved]
-(https://github.com/conformal/spectrwm/wiki/Scrotwm5.png)
+![mplayer, resized and moved](https://github.com/conformal/spectrwm/wiki/Scrotwm5.png)


### PR DESCRIPTION
Screenshot links are broken. Removing the line breaks fixes it.