### PR TITLE
Fixing link for xmonad in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ for much more important stuff. It has sane defaults and does not require one to
 learn a language to do any configuration. It is written by hackers for hackers
 and it strives to be small, compact and fast.
 
-It was largely inspired by [xmonad](http://xmonad.org xmonad) and
+It was largely inspired by [xmonad](http://xmonad.org) and
 [dwm](http://dwm.suckless.org). Both are fine products but suffer from things
 like: crazy-unportable-language-syndrome, silly defaults, asymmetrical window
 layout, "how hard can it be?" and good old NIH.  Nevertheless


### PR DESCRIPTION
Hi,

The name of the program xmonad was also provided where the link was meant to (according to Markdown syntax) be provided. The result was that this is what people see when reading the README:

> [xmonad](http://xmonad.org xmonad)

This commit merely fixes this issue. 

Thanks for your time,
Brenton