### PR TITLE
Silence -Wformat-truncation= warning with gcc7

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -6014,7 +6014,7 @@ search_win(struct binding *bp, struct swm_region *r, union arg *args)
 	uint32_t		wa[3];
 	xcb_screen_t		*screen;
 	int			i, width, height;
-	char			s[8];
+	char			s[11];
 	FILE			*lfile;
 	size_t			len;
 	XftDraw			*draw;


### PR DESCRIPTION
Silences the following warning with `GCC7` and `-O2`.
```
cc -Wl,--as-needed -fPIC -shared  -Wl,-soname,libswmhack.so.0.0 -o libswmhack.so.0.0 swm_hack.so -lX11  -ldl 
../spectrwm.c: In function ‘search_win’:
../spectrwm.c:6058:26: warning: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 8 [-Wformat-truncation=]
   snprintf(s, sizeof s, "%d", i);
                          ^~
../spectrwm.c:6058:25: note: directive argument in the range [1, 2147483647]
   snprintf(s, sizeof s, "%d", i);
                         ^~~~
../spectrwm.c:6058:3: note: ‘snprintf’ output between 2 and 11 bytes into a destination of size 8
   snprintf(s, sizeof s, "%d", i);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Please review.