### PR TITLE
Padding and alignment in the bar_format using '_' character

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -214,7 +214,11 @@ It may contain the following character sequences:
 .El
 .Pp
 All character sequences may limit its output to a specific length, for
-example +64A.
+example +64A. By default, no padding will be added if the length of the 
+replaced string is less than the specified length (64 in the example).
+The padding is enabled using a '_' character in the sequence. For 
+example: +_64W and +64_W will enable padding before window name and
+after window name, respectively.
 Any characters that don't match the specification are copied as-is.
 .It Ic bar_justify
 Justify the status bar text.

--- a/spectrwm.1
+++ b/spectrwm.1
@@ -214,11 +214,12 @@ It may contain the following character sequences:
 .El
 .Pp
 All character sequences may limit its output to a specific length, for
-example +64A. By default, no padding will be added if the length of the 
-replaced string is less than the specified length (64 in the example).
-The padding is enabled using a '_' character in the sequence. For 
-example: +_64W and +64_W will enable padding before window name and
-after window name, respectively.
+example +64A. By default, no padding/alignment is done in case the
+length of the replaced string is less than the specified length (64 in
+the example). The padding/alignment can be enabled using a '_' character
+in the sequence. For example: +_64W, +64_W and +_64_W enable padding before
+(right alignment), after (left alignment), and both before and after
+(center alignment) window name, respectively.
 Any characters that don't match the specification are copied as-is.
 .It Ic bar_justify
 Justify the status bar text.

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -2518,7 +2518,9 @@ bar_replace_seq(char *fmt, char *fmtrep, struct swm_region *r, size_t *offrep,
 	char			tmp[SWM_BAR_MAX];
 	int			limit, size, count;
 	size_t			len;
-	int pre_padding = 0, post_padding = 0, padding_len = 0;
+	int			pre_padding = 0;
+	int			post_padding = 0;
+	int			padding_len = 0;
 
 	/* reset strlcat(3) buffer */
 	*tmp = '\0';
@@ -2526,8 +2528,8 @@ bar_replace_seq(char *fmt, char *fmtrep, struct swm_region *r, size_t *offrep,
 	fmt++;
 	/* determine if pre-padding is requested */
 	if (*fmt == '_') {
-	    pre_padding = 1;
-	    fmt++;
+		pre_padding = 1;
+		fmt++;
 	}
 
 	/* get number, if any */
@@ -2539,10 +2541,10 @@ bar_replace_seq(char *fmt, char *fmtrep, struct swm_region *r, size_t *offrep,
 
 	fmt += size;
 
-    /* determine if post padding is requested*/
+	/* determine if post padding is requested*/
 	if (*fmt == '_') {
-	    post_padding = 1;
-	    fmt++;
+		post_padding = 1;
+		fmt++;
 	}
 
 	/* there is nothing to replace (ie EOL) */
@@ -2610,16 +2612,17 @@ bar_replace_seq(char *fmt, char *fmtrep, struct swm_region *r, size_t *offrep,
 	if (padding_len > 0) {
 		limit = len;
 
-	    if (pre_padding)
-	        pre_padding = padding_len/(pre_padding + post_padding);
-	    if (post_padding)
-	        post_padding = padding_len - pre_padding;
-    } else {
-        pre_padding = 0;
-        post_padding = 0;
-    }
+		if (pre_padding)
+			pre_padding = padding_len / (pre_padding +
+			    post_padding);
+		if (post_padding)
+			post_padding = padding_len - pre_padding;
+	} else {
+		pre_padding = 0;
+		post_padding = 0;
+	}
 
-    /* do pre padding */
+	/* do pre padding */
 	while (pre_padding-- > 0) {
 		if (*offrep >= sz - 1)
 			break;
@@ -2633,7 +2636,7 @@ bar_replace_seq(char *fmt, char *fmtrep, struct swm_region *r, size_t *offrep,
 		fmtrep[(*offrep)++] = *ptr++;
 	}
 
-    /* do post padding */
+	/* do post padding */
 	while (post_padding-- > 0) {
 		if (*offrep >= sz - 1)
 			break;


### PR DESCRIPTION
Hi,
First of all, thanks for creating this awesome (pun intended) window manager.

I have implemented a padding system in the `bar_format` that enables text alignment. My implementation uses the `'_'` character to specify the padding. 

For example: `+_100W` inserts padding (spaces) before the window name in case the length is less than 100, and truncates the window name to 100 characters if the length is more than 100. This effectively creates right-aligned text. Similarly, `+100_W` will enable padding after window name (left alignment) and `+_100_W` will enable padding both before and after the window name (center alignment).

This implementation seems to solve #99 and #29. 

I have been using this on my Macbook running ArchLinux for a few weeks and everything seems to work.

Example config:
`bar_format = ::[+_2I] +_9_D +96_W +_55A | %a %b %_d %l:%M %p`

Explanation:
- `+_2I` - produces 2-character wide, right aligned workspace index
- `+_9_D` - produces 9-character wide, center aligned workspace name
- `+96_W` - produces 96-character wide, left-aligned window name

Screenshot:
![Screenshot](https://user-images.githubusercontent.com/2763581/30135162-a54604d0-930e-11e7-9ac4-73d14ccaa0ac.png)

Please let me know what you think.
