### PR TITLE
Update config with new color options

### DIFF
--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -1,3 +1,4 @@
+
 # PLEASE READ THE MAN PAGE BEFORE EDITING THIS FILE!
 # https://htmlpreview.github.io/?https://github.com/conformal/spectrwm/blob/master/spectrwm.html
 # NOTE: all rgb color values in this file are in hex! see XQueryColor for examples
@@ -35,7 +36,9 @@
 # bar_border[1]		= rgb:00/80/80
 # bar_border_unfocus[1]	= rgb:00/40/40
 # bar_color[1]		= black
+# bar_color_seleccted[1]	= rgb:00/80/80
 # bar_font_color[1]	= rgb:a0/a0/a0
+# bar_font_color_selected	= black
 # bar_font		= -*-terminus-medium-*-*-*-*-*-*-*-*-*-*-*
 # bar_action		= baraction.sh
 # bar_justify		= left
@@ -88,7 +91,9 @@
 # Validated default programs:
 # program[lock]		= xlock
 # program[term]		= xterm
-# program[menu]		= dmenu_run $dmenu_bottom -fn $bar_font -nb $bar_color -nf $bar_font_color -sb $bar_border -sf $bar_color
+# program[menu]		= dmenu_run $dmenu_bottom -fn $bar_font -nb $bar_color -nf $bar_font_color -sb $bar_color_selected -sf $bar_font_color_selected
+# program[search]	= dmenu $dmenu_bottom -i -fn $bar_font -nb $bar_color -nf $bar_font_color -sb $bar_color_selected -sf $bar_font_color_selected
+# program[name_workspace]	= dmenu $dmenu_bottom -p Workspace -fn $bar_font -nb $bar_color -nf $bar_font_color -sb $bar_color_selected -sf $bar_font_color_selected
 
 # To disable validation of the above, free the respective binding(s):
 # bind[]		= MOD+Shift+Delete	# disable lock


### PR DESCRIPTION
Update example configuration file with new options bar_color_selected
and bar_font_color_selected.
Also update the example with dmenu to use the new colors.
Add two other dmenu examples, search and name_workspace, that was added
to the manual with the same commit as the new color options.

This was not done as part of the 22167bcf2fd2cbb22ffe89817f9c279804c8e0af  commit.