### PR TITLE
Fix OOB while reading bar input.

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -2761,7 +2761,7 @@ bar_extra_update(void)
 	while (fgets(b, sizeof(b), stdin) != NULL) {
 		if (bar_enabled) {
 			len = strlen(b);
-			if (b[len - 1] == '\n') {
+			if (len > 0 && b[len - 1] == '\n') {
 				/* Remove newline. */
 				b[--len] = '\0';
 


### PR DESCRIPTION
If the status bar script returns NUL as the first character through
stdin, spectrwm is prone to an out of boundary access. Depending on
the memory layout of the machine, it could turn into an OOB write.

The fix is simple: If the string is empty, do not further check for
newline character.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>