### PR TITLE
fix segmentation fault in font creation

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -2927,11 +2927,13 @@ fontset_init(void)
 
 		XFreeStringList(missing_charsets);
 
-		if (strcmp(default_string, ""))
-			warnx("Glyphs from those sets will be replaced "
-			    "by '%s'.", default_string);
-		else
-			warnx("Glyphs from those sets won't be drawn.");
+		if(bar_fs && default_string) {
+			if (strcmp(default_string, ""))
+				warnx("Glyphs from those sets will be replaced "
+				    "by '%s'.", default_string);
+			else
+				warnx("Glyphs from those sets won't be drawn.");
+		}
 	}
 
 	if (bar_fs == NULL)


### PR DESCRIPTION
For some reason that I still need to figure out, on one of my boxes the X font creation does not work.

However, something happens that I think according to ftp://www.x.org/pub/current/doc/man/man3/XCreateFontSet.3.xhtml shouldn't be possible:

* `XCreateFontSet` returns `NULL`, so `bar_fs` is `NULL`
* `num_missing_charsets` is set to `1`
* `default_string` is set to `NULL`

This leads to a segmentation fault when `strcmp(default_string, "")` is called.

By checking whether `bar_fs` is `NULL` prior to accessing `default_string`, this is circumvented.

