### PR TITLE
spectrwm.1: Silence mandoc style warnings.

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -650,13 +650,13 @@ stack_balance
 master_shrink
 .It Cm M-l
 master_grow
-.It Cm M-,
+.It Cm M-,\&
 master_add
-.It Cm M-.
+.It Cm M-.\&
 master_del
-.It Cm M-S-,
+.It Cm M-S-,\&
 stack_inc
-.It Cm M-S-.
+.It Cm M-S-.\&
 stack_dec
 .It Cm M- Ns Aq Cm Return
 swap_main
@@ -758,11 +758,11 @@ height_shrink
 height_grow
 .It Cm M-[
 move_left
-.It Cm M-]
+.It Cm M-]\&
 move_right
 .It Cm M-S-[
 move_up
-.It Cm M-S-]
+.It Cm M-S-]\&
 move_down
 .It Cm M-S-/
 name_workspace


### PR DESCRIPTION
This silences the following warnings reported by mandoc.
```
man: /usr/man/man1/spectrwm.1.gz:653:10: STYLE: no blank before trailing delimiter: Cm M-,
man: /usr/man/man1/spectrwm.1.gz:655:10: STYLE: no blank before trailing delimiter: Cm M-.
man: /usr/man/man1/spectrwm.1.gz:657:12: STYLE: no blank before trailing delimiter: Cm M-S-,
man: /usr/man/man1/spectrwm.1.gz:659:12: STYLE: no blank before trailing delimiter: Cm M-S-.
man: /usr/man/man1/spectrwm.1.gz:761:10: STYLE: no blank before trailing delimiter: Cm M-]
man: /usr/man/man1/spectrwm.1.gz:765:12: STYLE: no blank before trailing delimiter: Cm M-S-]
```
I did test this on my system, but please review to make sure its correct, thanks!