### PR TITLE
spectrwm.1: Silence mandoc warnings

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -228,7 +228,8 @@ All character sequences may limit its output to a specific length, for
 example +64A. By default, no padding/alignment is done in case the
 length of the replaced string is less than the specified length (64 in
 the example). The padding/alignment can be enabled using a '_' character
-in the sequence. For example: +_64W, +64_W and +_64_W enable padding before
+in the sequence.
+For example: +_64W, +64_W and +_64_W enable padding before
 (right alignment), after (left alignment), and both before and after
 (center alignment) window name, respectively.
 Any characters that don't match the specification are copied as-is.
@@ -983,7 +984,8 @@ Substituted for the currently defined
 .It Cm ANYMOD
 Select all modifier combinations not handled by another binding.
 .It Cm REPLAY
-Reprocess binding press/release events for other programs to handle.  Unavailable for
+Reprocess binding press/release events for other programs to handle.
+Unavailable for
 .Ic move ,
 .Ic resize
 and


### PR DESCRIPTION
Silences two more mandoc lint warnings.
```
man: /usr/man/man1/spectrwm.1.gz:231:18: WARNING: new sentence, new line
man: /usr/man/man1/spectrwm.1.gz:986:71: WARNING: new sentence, new line
```
```
new sentence, new line
(mdoc) A new sentence starts in the middle of a text line. Start it on a
new input line to help formatters produce correct spacing
```
https://man.openbsd.org/mandoc.1