### PR TITLE
Remove window border when there is only one window in workspace.

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -287,7 +287,7 @@ Some applications have dialogue windows that are too small to be useful.
 This ratio is the screen size to what they will be resized.
 For example, 0.6 is 60% of the physical screen size.
 .It Ic disable_border
-Remove border when bar is disabled and there is only one window on the region.
+Remove border when bar is disabled or there is only one window on the region.
 .It Ic focus_close
 Window to put focus when the focused window is closed.
 Possible values are

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -5504,7 +5504,7 @@ stack_master(struct workspace *ws, struct swm_geometry *g, int rot, bool flip)
 		/* Window coordinates exclude frame. */
 
 		if (winno > 1 || !disable_border ||
-		    (bar_enabled && ws->bar_enabled)) {
+		    (bar_enabled && ws->bar_enabled && winno > 1)) {
 			bordered = true;
 		} else {
 			bordered = false;

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -26,7 +26,7 @@
 # allowed outside the region.
 # boundary_width 		= 50
 
-# Remove window border when bar is disabled and there is only one window in workspace
+# Remove window border when bar is disabled or there is only one window in workspace.
 # disable_border		= 1
 
 # Bar Settings


### PR DESCRIPTION
I would expect that no border is shown if there is only window in a
workspace. This is the case when disable_border is set, and the bar is
disabled.
Reading the manpage closely I concluded that my expectation is wrong:

disable_border
    Remove border when bar is disabled and there is only one
    window on the region."

I was wondering if it makes sense to change behaviour of
'disable_border' to:

    Remove border when bar is disabled OR there is only one window
    on the region.