### PR TITLE
Extend disable_border option with `always`.

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -288,6 +288,12 @@ This ratio is the screen size to what they will be resized.
 For example, 0.6 is 60% of the physical screen size.
 .It Ic disable_border
 Remove border when bar is disabled and there is only one window on the region.
+Enable by setting to 1.
+Setting this to
+.Ar always
+removes border from lone tiled windows, regardless of the bar being
+enabled/disabled.
+Defaults to 0.
 .It Ic focus_close
 Window to put focus when the focused window is closed.
 Possible values are

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -409,6 +409,7 @@ bool		 focus_close_wrap = true;
 int		 focus_default = SWM_STACK_TOP;
 int		 spawn_position = SWM_STACK_TOP;
 bool		 disable_border = false;
+bool		 disable_border_always = false;
 int		 border_width = 1;
 int		 region_padding = 0;
 int		 tile_gap = 0;
@@ -5504,7 +5505,8 @@ stack_master(struct workspace *ws, struct swm_geometry *g, int rot, bool flip)
 		/* Window coordinates exclude frame. */
 
 		if (winno > 1 || !disable_border ||
-		    (bar_enabled && ws->bar_enabled)) {
+		    (bar_enabled && ws->bar_enabled &&
+		    !disable_border_always)) {
 			bordered = true;
 		} else {
 			bordered = false;
@@ -9261,7 +9263,8 @@ setconfvalue(const char *selector, const char *value, int flags)
 			dialog_ratio = .6;
 		break;
 	case SWM_S_DISABLE_BORDER:
-		disable_border = (atoi(value) != 0);
+		disable_border_always = (strcmp(value, "always") == 0);
+		disable_border = (atoi(value) != 0) || disable_border_always;
 		break;
 	case SWM_S_FOCUS_CLOSE:
 		if (strcmp(value, "first") == 0)

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -5504,13 +5504,8 @@ stack_master(struct workspace *ws, struct swm_geometry *g, int rot, bool flip)
 
 		/* Window coordinates exclude frame. */
 
-		if (winno > 1 || !disable_border ||
-		    (bar_enabled && ws->bar_enabled &&
-		    !disable_border_always)) {
-			bordered = true;
-		} else {
-			bordered = false;
-		}
+		bordered = winno > 1 || !disable_border || (bar_enabled &&
+		    ws->bar_enabled && !disable_border_always);
 
 		if (rot) {
 			if (X(win) != cell.y || Y(win) != cell.x ||


### PR DESCRIPTION
Instead of changing behaviour of `disable_border` (#221) extend it with `always`. Setting `disable_border = always` consistently removes border from lone tiled windows, regardless of the bar being enabled/disabled.

Existing behaviour remains unchanged.
 