### PR TITLE
Setting bar_font simply overwrites previous values

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -158,7 +158,7 @@ be used regardless of missing glyphs.
 The default is to use font set.
 Also note that
 .Xr dmenu 1
-does not support Xft fonts.
+versions before 1.6 do not support Xft fonts.
 .Pp
 Xft examples:
 .Bd -literal -offset indent

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -9157,7 +9157,7 @@ setconfvalue(const char *selector, const char *value, int flags)
 {
 	struct workspace	*ws;
 	int			i, ws_id, num_screens, n;
-	char			*b, *str, *sp;
+	char			*b, *sp;
 
 	switch (flags) {
 	case SWM_S_BAR_ACTION:
@@ -9189,20 +9189,14 @@ setconfvalue(const char *selector, const char *value, int flags)
 		}
 		break;
 	case SWM_S_BAR_FONT:
-		b = bar_fonts;
-		if (asprintf(&bar_fonts, "%s,%s", value, bar_fonts) == -1)
-			err(1, "setconfvalue: asprintf: failed to allocate "
-				"memory for bar_fonts.");
-		free(b);
-
-		/* If already in xft mode, then we are done. */
-		if (!bar_font_legacy)
-			break;
-
-		if ((sp = str = strdup(value)) == NULL)
+		free(bar_fonts);
+		if ((bar_fonts = strdup(value)) == NULL)
 			err(1, "setconfvalue: strdup");
 
 		/* If there are any non-XLFD entries, switch to Xft mode. */
+		sp = bar_fonts;
+		bar_font_legacy = true;
+
 		while ((b = strsep(&sp, ",")) != NULL) {
 			if (*b == '\0')
 				continue;
@@ -9212,7 +9206,6 @@ setconfvalue(const char *selector, const char *value, int flags)
 			}
 		}
 
-		free(str);
 		break;
 	case SWM_S_BAR_FORMAT:
 		free(bar_format);


### PR DESCRIPTION
When configuring bar_font, the behavior of retaining the prior default
values broke dmenu_run in the common case of specifying one Xft font
spec with size attribute.

Now that setting bar_font multiple times overwrites the previous value,
bar_font_legacy is always recalculated.

spectrm#223