### PR TITLE
Silence warning reported by the clang static analyzer.

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -6228,7 +6228,7 @@ search_win(struct binding *bp, struct swm_region *r, union arg *args)
 	XGlyphInfo		info;
 	GC			l_draw;
 	XGCValues		l_gcv;
-	XRectangle		l_ibox, l_lbox;
+	XRectangle		l_ibox, l_lbox = {0, 0, 0, 0};
 
 	(void)bp;
 


### PR DESCRIPTION
Silence the warning below, although it is highly unlikely that one encounters an issue related to it.

```
spectrwm.c:6300:51: warning: The right operand of '-' is a garbage value
                            (bar_fs_extents->max_logical_extent.height -
                                                                       ^
```