### PR TITLE
Fix infinite loop due to unsigned integer overflow.

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -8638,10 +8638,17 @@ get_binding_keycode(struct binding *bp)
 
 	/* Search for keycode by keysym column. */
 	for (col = 0; col < kmr->keysyms_per_keycode; col++) {
-		for (i = min; i <= max; i++) {
+		for (i = min; ; i++) {
 			if (xcb_key_symbols_get_keysym(syms, i, col) ==
 			    bp->value)
 				return (i);
+			/*
+			 * Always check before incrementing i in order to avoid
+			 * an infinite loop due to an unsigned integer overlow
+			 * of i.
+			 */
+			if (i >= max)
+				break;
 		}
 	}
 


### PR DESCRIPTION
In get_binding_keycode() a uint8_t loop variable was incremented in a
for loop.  The variable would overflow right before the loop's
condition was met.  Therefore the loop would never terminate.

To avoid the infinite loop the condition has to be checked before the
increment operation and not afterwards.