### PR TITLE
Fix buffer overflow in bar_strlcat_esc

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -3058,8 +3058,8 @@ bar_strlcat_esc(char *dst, char *src, size_t sz)
 	}
 
 	/* Concat string and escape every '+' */
-	while (*src != '\0' && sz != 0) {
-		if ((*src == '+') && (sz > 1)) {
+	while (*src != '\0' && sz > 1) {
+		if ((*src == '+') && (sz > 2)) {
 			*dst++ = '+';
 			sz--;
 		}


### PR DESCRIPTION
This patch fix a buffer overflow introduced by the multisection commit in the function bar_strlcat_esc. This function can overwrite the ending '\0' in the destination string when the source overflows the destination. This fixes the issue.