### PR TITLE
Link libswmhack against libX11

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -15,6 +15,7 @@ NOPROFILE= yes
 CFLAGS+= -std=c99 -Wmissing-prototypes -Wall -Wextra -Wshadow -Wno-uninitialized -g
 CFLAGS+= -fPIC
 CFLAGS+= -I${X11BASE}/include
+LDADD+= -L${X11BASE}/lib -lX11
 
 install:
 	${INSTALL} ${INSTALL_COPY} -o ${LIBOWN} -g ${LIBGRP} -m ${LIBMODE} \


### PR DESCRIPTION
I'm currently running spectrwm HEAD on OpenBSD current. When starting a tool from urxvt I'm seeing the following:

```
$ ncspot
ncspot:/usr/local/lib/libswmhack.so.1.0: undefined symbol 'XKeysymToKeycode'
```

It seems that `XKeysymToKeycode` is seen as a normal symbol while actually it is a function:

```
$ objdump -T libswmhack.so.1.0.orig

libswmhack.so.1.0.orig:     file format elf64-x86-64

DYNAMIC SYMBOL TABLE:
0000000000000000  w   D  *UND*	0000000000000000 _Jv_RegisterClasses
0000000000000000  w   D  *UND*	0000000000000000 __cxa_atexit
0000000000000000  w   D  *UND*	0000000000000000 __cxa_finalize
0000000000000000  w   D  *UND*	0000000000000000 _thread_atfork
0000000000000000      D  *UND*	0000000000000000 XKeysymToKeycode
0000000000000000      D  *UND*	0000000000000000 __sF
0000000000000000      D  *UND*	0000000000000000 dlerror
0000000000000000      D  *UND*	0000000000000000 dlopen
0000000000000000      D  *UND*	0000000000000000 dlsym
0000000000000000      D  *UND*	0000000000000000 fprintf
0000000000000000      D  *UND*	0000000000000000 getenv
0000000000000000      D  *UND*	0000000000000000 snprintf
0000000000000000      D  *UND*	0000000000000000 strlen
0000000000000000      D  *UND*	0000000000000000 unsetenv
0000000000001ab0 g    DF .fini	0000000000000000 _fini
0000000000001aa0 g    DF .init	0000000000000000 _init
00000000000011b0 g    DF .text	00000000000000e0 get_atom_from_string
00000000000017b0 g    DF .text	0000000000000190 XCreateSimpleWindow
0000000000001610 g    DF .text	00000000000001a0 XCreateWindow
00000000000013c0 g    DF .text	0000000000000250 XOpenDisplay
0000000000001940 g    DF .text	0000000000000151 XtAppNextEvent
0000000000001290 g    DF .text	0000000000000130 set_property

```
Linking libswmhack against libX11 fixes this issue:

```
$ diff -up dump_libswmhack.so.1.0.orig dump_libswmhack.so.1.0
--- dump_libswmhack.so.1.0.orig	Sun Nov 24 22:14:21 2019
+++ dump_libswmhack.so.1.0	Sun Nov 24 22:15:20 2019
@@ -1,12 +1,12 @@

-libswmhack.so.1.0.orig:     file format elf64-x86-64
+libswmhack.so.1.0:     file format elf64-x86-64

 DYNAMIC SYMBOL TABLE:
 0000000000000000  w   D  *UND*	0000000000000000 _Jv_RegisterClasses
 0000000000000000  w   D  *UND*	0000000000000000 __cxa_atexit
 0000000000000000  w   D  *UND*	0000000000000000 __cxa_finalize
 0000000000000000  w   D  *UND*	0000000000000000 _thread_atfork
-0000000000000000      D  *UND*	0000000000000000 XKeysymToKeycode
+0000000000000000      DF *UND*	0000000000000000 XKeysymToKeycode
 0000000000000000      D  *UND*	0000000000000000 __sF
 0000000000000000      D  *UND*	0000000000000000 dlerror
 0000000000000000      D  *UND*	0000000000000000 dlopen
```