### PR TITLE
Assign ws_prior

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -12398,8 +12398,8 @@ void
 new_region(struct swm_screen *s, int x, int y, int w, int h)
 {
 	struct swm_region	*r = NULL, *n;
-	struct workspace	*ws = NULL;
-	int			i;
+	struct workspace	*ws = NULL, *ws_prior = NULL;
+	int			i, ws_idx;
 	uint32_t		wa[1];
 
 	DNPRINTF(SWM_D_MISC, "screen[%d]:%dx%d+%d+%d\n", s->idx, w, h, x, y);
@@ -12450,6 +12450,7 @@ new_region(struct swm_screen *s, int x, int y, int w, int h)
 		for (i = 0; i < workspace_limit; i++)
 			if (s->ws[i].r == NULL) {
 				ws = &s->ws[i];
+				ws_idx = i++;
 				break;
 			}
 	}
@@ -12460,6 +12461,15 @@ new_region(struct swm_screen *s, int x, int y, int w, int h)
 	if (ws->state == SWM_WS_STATE_HIDDEN)
 		ws->state = SWM_WS_STATE_MAPPING;
 
+	/* try to assign prior workspace to the next free workspace */
+	if (ws_prior == NULL && ws_idx < workspace_limit) {
+		for (i = ws_idx; i < workspace_limit; i++)
+			if (s->ws[i].r == NULL) {
+				ws_prior = &s->ws[i];
+				break;
+			}
+	}
+
 	X(r) = x;
 	Y(r) = y;
 	WIDTH(r) = w;
@@ -12467,7 +12477,7 @@ new_region(struct swm_screen *s, int x, int y, int w, int h)
 	r->bar = NULL;
 	r->s = s;
 	r->ws = ws;
-	r->ws_prior = NULL;
+	r->ws_prior = ws_prior;
 	ws->r = r;
 	outputs++;
 	TAILQ_INSERT_TAIL(&s->rl, r, entry);

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -12450,7 +12450,7 @@ new_region(struct swm_screen *s, int x, int y, int w, int h)
 		for (i = 0; i < workspace_limit; i++)
 			if (s->ws[i].r == NULL) {
 				ws = &s->ws[i];
-				ws_idx = i++;
+				ws_idx = i + 1;
 				break;
 			}
 	}


### PR DESCRIPTION
As a convert from dwm, I'm used to having ws_prior preset.

The proposed solution is not dry: The two loops searching for a free workspace beg for encapsulation. On the other hand, with ws_idx introduced to the code (there may be a smarter solution), the function would have to return both ws_idx and the free workspace, and I'm not sure if I can implement that with my modest C programming skills. So I'm sharing this as it is to hear your thoughts.

I tested this with workspace_limit set to 4 and then to 1. I did not test it for multiple regions, though.