### PR TITLE
linux: Accept user-provided pkg-config command

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -6,6 +6,7 @@ DATAROOTDIR  ?= $(PREFIX)/share
 MANDIR       ?= $(DATAROOTDIR)/man
 DOCDIR       ?= $(DATAROOTDIR)/doc/spectrwm
 XSESSIONSDIR ?= $(DATAROOTDIR)/xsessions
+PKG_CONFIG   ?= pkg-config
 
 BUILDVERSION    = $(shell sh $(CURDIR)/../buildver.sh)
 LIBVERSION      = $(shell .  $(CURDIR)/../lib/shlib_version; echo $$major.$$minor)
@@ -21,12 +22,12 @@ endif
 
 BIN_CFLAGS   = -fPIE
 BIN_LDFLAGS  = -fPIE -pie
-BIN_CPPFLAGS = $(shell pkg-config --cflags x11 x11-xcb xcb-icccm xcb-keysyms xcb-randr xcb-util xcb-xinput xcb-xtest xcursor xft)
-BIN_LDLIBS   = $(shell pkg-config --libs   x11 x11-xcb xcb-icccm xcb-keysyms xcb-randr xcb-util xcb-xinput xcb-xtest xcursor xft)
+BIN_CPPFLAGS = $(shell $(PKG_CONFIG) --cflags x11 x11-xcb xcb-icccm xcb-keysyms xcb-randr xcb-util xcb-xinput xcb-xtest xcursor xft)
+BIN_LDLIBS   = $(shell $(PKG_CONFIG) --libs   x11 x11-xcb xcb-icccm xcb-keysyms xcb-randr xcb-util xcb-xinput xcb-xtest xcursor xft)
 LIB_CFLAGS   = -fPIC
 LIB_LDFLAGS  = -fPIC -shared
-LIB_CPPFLAGS = $(shell pkg-config --cflags x11)
-LIB_LDLIBS   = $(shell pkg-config --libs   x11) -ldl
+LIB_CPPFLAGS = $(shell $(PKG_CONFIG) --cflags x11)
+LIB_LDLIBS   = $(shell $(PKG_CONFIG) --libs   x11) -ldl
 
 all: spectrwm libswmhack.so.$(LIBVERSION)
 


### PR DESCRIPTION
Submitted on behalf of Helmut Grohne, who provided the patch as part of his effort to fix [Debian bug #928902](https://bugs.debian.org/928902). This patch is necessary for spectrwm to cross-build correctly.