### PR TITLE
Implement workspace pinning

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -610,7 +610,7 @@ if you want to focus on the region containing the workspace and
 .Ar warp_pointer
 if you want to also send the pointer.
 Enable by setting to 1.
-.It Ic workspace_pin
+.It Ic workspace_auto_pin
 Pins every workspace to the region where it first appeared.
 The focus warping is analogous to how
 .Ar workspace_clamp

--- a/spectrwm.1
+++ b/spectrwm.1
@@ -610,6 +610,13 @@ if you want to focus on the region containing the workspace and
 .Ar warp_pointer
 if you want to also send the pointer.
 Enable by setting to 1.
+.It Ic workspace_pin
+Pins every workspace to the region where it first appeared.
+The focus warping is analogous to how
+.Ar workspace_clamp
+handles that. If you want to unpin a workspace, you can release it with
+.Ar ws_release
+binding. Empty workspaces are unpinned by default.
 .It Ic window_class_enabled
 Enable or disable displaying the window class name (from WM_CLASS) in the
 status bar.
@@ -926,6 +933,8 @@ move_right
 move_up
 .It Cm M-S-]\&
 move_down
+.It Cm M-S-a
+ws_release
 .It Cm M-S-/
 name_workspace
 .It Cm M-/
@@ -1122,6 +1131,8 @@ Move a floating window a step to the right.
 Move a floating window a step upwards.
 .It Cm move_down
 Move a floating window a step downwards.
+.It Cm ws_release
+Unpin a workspace from a region.
 .It Cm name_workspace
 Name the current workspace.
 .It Cm search_workspace

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -336,7 +336,7 @@ uint16_t		mod_key = MODKEY;
 bool			warp_focus = false;
 bool			warp_pointer = false;
 bool			workspace_clamp = false;
-bool			workspace_pin = false;
+bool			workspace_auto_pin = false;
 
 /* dmenu search */
 struct swm_region	*search_r;
@@ -4922,7 +4922,7 @@ switchws(struct binding *bp, struct swm_region *r, union arg *args)
 		return;
 
 	other_r = new_ws->r;
-	if (workspace_pin && new_ws->pin_r && new_ws->pin_r != this_r
+	if (workspace_auto_pin && new_ws->pin_r && new_ws->pin_r != this_r
 		&& new_ws->winlist.tqh_first && !other_r) {
 		DNPRINTF(SWM_D_WS,
 		    "warping focus to previous region %p"
@@ -4937,7 +4937,7 @@ switchws(struct binding *bp, struct swm_region *r, union arg *args)
 		return switchws(NULL, new_ws->pin_r, args);
 	}
 
-	if (other_r && (workspace_clamp || (workspace_pin && new_ws->do_pin))
+	if (other_r && (workspace_clamp || (workspace_auto_pin && new_ws->do_pin))
 	    && (bp == NULL
 	     || (bp->action != FN_RG_MOVE_NEXT && bp->action != FN_RG_MOVE_PREV))) {
 		DNPRINTF(SWM_D_WS, "ws clamped.\n");
@@ -4951,7 +4951,7 @@ switchws(struct binding *bp, struct swm_region *r, union arg *args)
 		return;
 	}
 
-        if (workspace_pin) {
+        if (workspace_auto_pin) {
           if (old_ws->do_pin)
             old_ws->pin_r = this_r;
           else
@@ -4966,7 +4966,7 @@ switchws(struct binding *bp, struct swm_region *r, union arg *args)
 		    &none);
 	}
 
-        if (other_r && workspace_pin && old_ws->pin_r) {
+        if (other_r && workspace_auto_pin && old_ws->pin_r) {
           /* the other ws is visible but pinned, we cannot exchange
              it, so we move it and switch the old region to the prior
              ws */
@@ -5058,7 +5058,7 @@ releasews(struct binding *bp, struct swm_region *r, union arg *args)
 	(void)bp;
 	(void)args;
 
-	if(!workspace_pin || !r->ws)
+	if(!workspace_auto_pin || !r->ws)
 		return;
 
 	r->ws->pin_r = NULL;
@@ -9797,7 +9797,7 @@ enum {
 	SWM_S_WINDOW_INSTANCE_ENABLED,
 	SWM_S_WINDOW_NAME_ENABLED,
 	SWM_S_WORKSPACE_CLAMP,
-	SWM_S_WORKSPACE_PIN,
+	SWM_S_WORKSPACE_AUTO_PIN,
 	SWM_S_WORKSPACE_LIMIT,
 	SWM_S_WORKSPACE_INDICATOR,
 	SWM_S_WORKSPACE_NAME,
@@ -10055,8 +10055,8 @@ setconfvalue(const char *selector, const char *value, int flags, char **emsg)
 	case SWM_S_WORKSPACE_CLAMP:
 		workspace_clamp = (atoi(value) != 0);
 		break;
-	case SWM_S_WORKSPACE_PIN:
-		workspace_pin = (atoi(value) != 0);
+	case SWM_S_WORKSPACE_AUTO_PIN:
+		workspace_auto_pin = (atoi(value) != 0);
 		break;
 	case SWM_S_WORKSPACE_LIMIT:
 		workspace_limit = atoi(value);
@@ -10514,7 +10514,7 @@ struct config_option configopt[] = {
 	{ "window_instance_enabled",	setconfvalue,	SWM_S_WINDOW_INSTANCE_ENABLED },
 	{ "window_name_enabled",	setconfvalue,	SWM_S_WINDOW_NAME_ENABLED },
 	{ "workspace_clamp",		setconfvalue,	SWM_S_WORKSPACE_CLAMP },
-	{ "workspace_pin",		setconfvalue,	SWM_S_WORKSPACE_PIN },
+	{ "workspace_auto_pin",		setconfvalue,	SWM_S_WORKSPACE_AUTO_PIN },
 	{ "workspace_limit",		setconfvalue,	SWM_S_WORKSPACE_LIMIT },
 	{ "workspace_indicator",	setconfvalue,	SWM_S_WORKSPACE_INDICATOR },
 	{ "name",			setconfvalue,	SWM_S_WORKSPACE_NAME },
@@ -13452,7 +13452,7 @@ main(int argc, char *argv[])
 		}
 
 	/* Init pinning for all workspaces. */
-	if (workspace_pin) {
+	if (workspace_auto_pin) {
 		for (i = 0; i < num_screens; i++) {
 		    for (int j = 0; j < SWM_WS_MAX; j++) {
 			screens[i].ws[j].do_pin = true;

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -9,6 +9,7 @@
 # focus_default		= last
 # spawn_position		= next
 # workspace_clamp	= 1
+# workspace_pin	= 1
 # warp_focus		= 1
 # warp_pointer		= 1
 

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -9,7 +9,7 @@
 # focus_default		= last
 # spawn_position		= next
 # workspace_clamp	= 1
-# workspace_pin	= 1
+# workspace_auto_pin	= 1
 # warp_focus		= 1
 # warp_pointer		= 1
 

--- a/spectrwm_us.conf
+++ b/spectrwm_us.conf
@@ -27,6 +27,7 @@ bind[move_down]		= MOD+Shift+bracketright
 bind[move_left]		= MOD+bracketleft
 bind[move_right]	= MOD+bracketright
 bind[move_up]		= MOD+Shift+bracketleft
+bind[ws_release]	= MOD+Shift+a
 bind[mvrg_1]		= MOD+Shift+KP_End
 bind[mvrg_2]		= MOD+Shift+KP_Down
 bind[mvrg_3]		= MOD+Shift+KP_Next


### PR DESCRIPTION
This implements the feature requested in #239.

It adds the option `workspace_pin`. Setting this option to `1` will pin any workspace to the region where it appeared first (the region is set when switching workspaces). To unpin a workspace, the keybinding `ws_release` has been introduced.  Empty workspaces are automatically unpinned.
The formatting is all wrong (tabs/spaces). I will have to fix that, but wanted to gauge the interest in merging this first.

Cheers.

# Detailed Example
 1. region 1 has workspace 1, i am switching to workspace 2 (which is not visible)
 2. spectrwm rembers that ws 1 was on region 1 and switches to ws 2
 3. now i move to another region and switch back to ws 1: this opens ws 1 on region 1 (and warps focus and pointer there, if enabled)
 4. i unpin the workspace an switch to another workspace
 5. when i switch to ws 1 now, it opens on the current region as if workspace pinning wasn't enabled and gets pinned as in step 2

## Todo
- [ ] fix formatting
- [ ] add keybinding to toggle pinning globally 
- [ ] maybe pre-pin workspaces in config
- [ ] make automatic pinning configurable
- [x] only pin, if there is a window on the workspace