### PR TITLE
added printonlynames option to workspace_indicator

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -665,6 +665,8 @@ Indicate the current workspace if it is in the list.
 Indicate workspaces in the list that contain urgent window(s).
 .It Ar printnames
 Display the names of named workspaces in the list.
+.It Ar printonlynames
+Display only the names of named workspaces in the list.
 .El
 .Pp
 The default is

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -303,6 +303,7 @@ uint32_t		swm_debug = 0
 #define SWM_WSI_MARKCURRENT	(0x200)
 #define SWM_WSI_MARKURGENT	(0x400)
 #define SWM_WSI_PRINTNAMES	(0x800)
+#define SWM_WSI_PRINTONLYNAMES	(0x1000)
 #define SWM_WSI_DEFAULT		(SWM_WSI_LISTCURRENT | SWM_WSI_LISTACTIVE |	\
     SWM_WSI_MARKCURRENT | SWM_WSI_PRINTNAMES)
 
@@ -2764,6 +2765,8 @@ bar_workspace_indicator(char *s, size_t sz, struct swm_region *r)
 			if (named && workspace_indicator & SWM_WSI_PRINTNAMES)
 				snprintf(tmp, sizeof tmp, "%d:%s", ws->idx + 1,
 				    ws->name);
+      else if (named && workspace_indicator & SWM_WSI_PRINTONLYNAMES)
+				snprintf(tmp, sizeof tmp, "%s", ws->name);
 			else
 				snprintf(tmp, sizeof tmp, "%d", ws->idx + 1);
 			strlcat(s, tmp, sz);
@@ -9587,6 +9590,7 @@ struct wsi_flag {
 	{"markcurrent", SWM_WSI_MARKCURRENT},
 	{"markurgent", SWM_WSI_MARKURGENT},
 	{"printnames", SWM_WSI_PRINTNAMES},
+	{"printonlynames", SWM_WSI_PRINTONLYNAMES},
 };
 
 #define SWM_FLAGS_DELIM		","


### PR DESCRIPTION
This option will display the names alone without the number when `named && workspace_indicator & SWM_WSI_PRINTONLYNAMES` so you don't get the annoying number:name if you don't like it. 