### PR TITLE
Added Ability to change the marking symbols for current and urgent workspaces. 

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -671,6 +671,10 @@ Display only the names of named workspaces in the list.
 .Pp
 The default is
 .Ar listcurrent , Ns Ar listactive , Ns Ar markcurrent , Ns Ar printnames
+.It Ic current_mark
+set the mark symbol for marking current workspace, default is *
+.It Ic urgent_mark
+set the mark symbol for marking urgent workspace, default is !
 .It Ic workspace_limit
 Set the total number of workspaces available.
 Minimum is 1, maximum is 22, default is 10.

--- a/spectrwm.1
+++ b/spectrwm.1
@@ -665,6 +665,8 @@ Indicate the current workspace if it is in the list.
 Indicate workspaces in the list that contain urgent window(s).
 .It Ar printnames
 Display the names of named workspaces in the list.
+.It Ar printonlynames
+Display only the names of named workspaces in the list.
 .El
 .Pp
 The default is

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -303,6 +303,7 @@ uint32_t		swm_debug = 0
 #define SWM_WSI_MARKCURRENT	(0x200)
 #define SWM_WSI_MARKURGENT	(0x400)
 #define SWM_WSI_PRINTNAMES	(0x800)
+#define SWM_WSI_PRINTONLYNAMES	(0x1000)
 #define SWM_WSI_DEFAULT		(SWM_WSI_LISTCURRENT | SWM_WSI_LISTACTIVE |	\
     SWM_WSI_MARKCURRENT | SWM_WSI_PRINTNAMES)
 
@@ -2764,6 +2765,8 @@ bar_workspace_indicator(char *s, size_t sz, struct swm_region *r)
 			if (named && workspace_indicator & SWM_WSI_PRINTNAMES)
 				snprintf(tmp, sizeof tmp, "%d:%s", ws->idx + 1,
 				    ws->name);
+      else if (named && workspace_indicator & SWM_WSI_PRINTONLYNAMES)
+				snprintf(tmp, sizeof tmp, "%s", ws->name);
 			else
 				snprintf(tmp, sizeof tmp, "%d", ws->idx + 1);
 			strlcat(s, tmp, sz);
@@ -9587,6 +9590,7 @@ struct wsi_flag {
 	{"markcurrent", SWM_WSI_MARKCURRENT},
 	{"markurgent", SWM_WSI_MARKURGENT},
 	{"printnames", SWM_WSI_PRINTNAMES},
+	{"printonlynames", SWM_WSI_PRINTONLYNAMES},
 };
 
 #define SWM_FLAGS_DELIM		","

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -460,6 +460,8 @@ int		num_bg_colors = 1;
 XftColor	search_font_color;
 char		*startup_exception = NULL;
 unsigned int	 nr_exceptions = 0;
+char *current_mark = NULL;
+char *urgent_mark = NULL;
 
 /* layout manager data */
 struct swm_geometry {
@@ -2752,10 +2754,10 @@ bar_workspace_indicator(char *s, size_t sz, struct swm_region *r)
 
 			if (current &&
 			    workspace_indicator & SWM_WSI_MARKCURRENT)
-				mark = "*";
+				mark = current_mark;
 			else if (urgent && workspace_indicator &
 			    SWM_WSI_MARKURGENT)
-				mark = "!";
+				mark = urgent_mark;
 			else if (!collapse)
 				mark = " ";
 			else
@@ -9992,6 +9994,8 @@ enum {
 	SWM_S_WORKSPACE_LIMIT,
 	SWM_S_WORKSPACE_INDICATOR,
 	SWM_S_WORKSPACE_NAME,
+  SWM_S_CURRENT_MARK,
+  SWM_S_URGENT_MARK,
 };
 
 int
@@ -10288,6 +10292,16 @@ setconfvalue(const char *selector, const char *value, int flags, char **emsg)
 			ewmh_update_desktop_names();
 			ewmh_get_desktop_names();
 		}
+		break;
+  case SWM_S_CURRENT_MARK:
+		free(current_mark);
+		if ((current_mark = strdup(value)) == NULL)
+			err(1, "setconfvalue: current_mark");
+		break;
+  case SWM_S_URGENT_MARK:
+		free(urgent_mark);
+		if ((urgent_mark = strdup(value)) == NULL)
+			err(1, "setconfvalue: urgent_mark");
 		break;
 	default:
 		ALLOCSTR(emsg, "invalid option");
@@ -10705,6 +10719,8 @@ struct config_option configopt[] = {
 	{ "workspace_limit",		setconfvalue,	SWM_S_WORKSPACE_LIMIT },
 	{ "workspace_indicator",	setconfvalue,	SWM_S_WORKSPACE_INDICATOR },
 	{ "name",			setconfvalue,	SWM_S_WORKSPACE_NAME },
+	{ "current_mark",			setconfvalue,	SWM_S_CURRENT_MARK },
+	{ "urgent_mark",			setconfvalue,	SWM_S_URGENT_MARK },
 };
 
 void
@@ -13284,6 +13300,10 @@ setup_globals(void)
 
 	if ((syms = xcb_key_symbols_alloc(conn)) == NULL)
 		errx(1, "unable to allocate key symbols.");
+  if ((current_mark = strdup ("*")) == NULL)
+      err(1, "current_mark: strdup");
+  if ((urgent_mark = strdup ("!")) == NULL)
+      err(1, "urgent_mark: strdup");
 
 	a_state = get_atom_from_string("WM_STATE");
 	a_prot = get_atom_from_string("WM_PROTOCOLS");

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -46,6 +46,8 @@
 # bar_justify		= left
 # bar_format		= +N:+I +S <+D>+4<%a %b %d %R %Z %Y+8<+A+4<+V
 # workspace_indicator	= listcurrent,listactive,markcurrent,printnames
+# current_mark = *
+# urgent_mark = !
 # bar_at_bottom		= 1
 # stack_enabled		= 1
 # clock_enabled		= 1


### PR DESCRIPTION
Added ability to change the mark for current and urgent workspaces though the config file

the options in spectrwm.config are as following
```
current_mark = *
urgent_mark = !
```
This makes it possibole for the user to change the symbols as well as add colors used +@fg and +@bg markup options. 