### PR TITLE
workspace Indicator and bar enhancments

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -491,6 +491,26 @@ the
 option.
 .Pp
 This setting is not retained at restart.
+.It Ic stack_mark_max
+change the mark for the
+.Ic stack_mod
+layout stacking algorithm indecator, default is [ ].
+.It Ic stack_mark_vertical
+change the mark for the
+.Ic vertical
+layout stacking algorithm indecator, default is [|].
+.It Ic stack_mark_vertical_flip
+change the mark for the
+.IC vertical_flip
+layout stacking algorithm indecator, default is [>].
+.It Ic stack_mark_horizontal
+change the mark for the
+.Ic horizontal
+layout stacking algorithm indecator, default is [-].
+.It Ic stack_mark_horizontal_flip
+change the mark for
+.Ic the horizontal_flip
+layout stacking algorithm indecator, default is [v].
 .It Ic maximize_hide_bar
 When set to 1,
 .Ic maximize_toggle
@@ -664,12 +684,26 @@ Always exclude the current workspace from the list.
 Indicate the current workspace if it is in the list.
 .It Ar markurgent
 Indicate workspaces in the list that contain urgent window(s).
+.It Ar markactive
+Indicate workspaces in the list that are active.
+.It Ar markempty
+Indicate workspaces in the list that are empty.
 .It Ar printnames
 Display the names of named workspaces in the list.
+.It Ar noindexes
+hide the index of the workspaces.
 .El
 .Pp
 The default is
 .Ar listcurrent , Ns Ar listactive , Ns Ar markcurrent , Ns Ar printnames
+.It Ic workspace_mark_current
+set the mark symbol for marking current workspace, default is *
+.It Ic workspace_mark_urgent
+set the mark symbol for marking urgent workspaces, default is !
+.It Ic workspace_mark_active
+set the mark symbol for marking active workspaces, default is ^
+.It Ic workspace_mark_empty
+set the mark symbol for marking empty workspaces, default is -
 .It Ic workspace_limit
 Set the total number of workspaces available.
 Minimum is 1, maximum is 22, default is 10.

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -302,7 +302,10 @@ uint32_t		swm_debug = 0
 #define SWM_WSI_HIDECURRENT	(0x100)
 #define SWM_WSI_MARKCURRENT	(0x200)
 #define SWM_WSI_MARKURGENT	(0x400)
-#define SWM_WSI_PRINTNAMES	(0x800)
+#define SWM_WSI_MARKACTIVE	(0x800)
+#define SWM_WSI_MARKEMPTY	(0x1000)
+#define SWM_WSI_PRINTNAMES	(0x2000)
+#define SWM_WSI_NOINDEXES	(0x4000)
 #define SWM_WSI_DEFAULT		(SWM_WSI_LISTCURRENT | SWM_WSI_LISTACTIVE |	\
     SWM_WSI_MARKCURRENT | SWM_WSI_PRINTNAMES)
 
@@ -462,6 +465,15 @@ int		num_bg_colors = 1;
 XftColor	search_font_color;
 char		*startup_exception = NULL;
 unsigned int	 nr_exceptions = 0;
+char    *workspace_mark_current = NULL;
+char    *workspace_mark_urgent = NULL;
+char    *workspace_mark_active = NULL;
+char    *workspace_mark_empty = NULL;
+char    *stack_mark_max = NULL;
+char    *stack_mark_vertical = NULL;
+char    *stack_mark_vertical_flip = NULL;
+char    *stack_mark_horizontal = NULL;
+char    *stack_mark_horizontal_flip = NULL;
 
 /* layout manager data */
 struct swm_geometry {
@@ -2321,12 +2333,12 @@ fancy_stacker(struct workspace *ws)
 void
 plain_stacker(struct workspace *ws)
 {
-	strlcpy(ws->stacker, "[ ]", sizeof ws->stacker);
+	strlcpy(ws->stacker, stack_mark_max, sizeof ws->stacker);
 	if (ws->cur_layout->l_stack == vertical_stack)
-		strlcpy(ws->stacker, ws->l_state.vertical_flip ? "[>]" : "[|]",
+		strlcpy(ws->stacker, ws->l_state.vertical_flip ? stack_mark_vertical_flip : stack_mark_vertical,
 		    sizeof ws->stacker);
 	else if (ws->cur_layout->l_stack == horizontal_stack)
-		strlcpy(ws->stacker, ws->l_state.horizontal_flip ? "[v]" : "[-]",
+		strlcpy(ws->stacker, ws->l_state.horizontal_flip ? stack_mark_horizontal_flip : stack_mark_horizontal,
 		    sizeof ws->stacker);
 }
 
@@ -2752,21 +2764,29 @@ bar_workspace_indicator(char *s, size_t sz, struct swm_region *r)
 			if (count > 0)
 				strlcat(s, " ", sz);
 
-			if (current &&
-			    workspace_indicator & SWM_WSI_MARKCURRENT)
-				mark = "*";
-			else if (urgent && workspace_indicator &
-			    SWM_WSI_MARKURGENT)
-				mark = "!";
+			if (current && workspace_indicator & SWM_WSI_MARKCURRENT)
+				mark = workspace_mark_current;
+			else if (urgent && workspace_indicator & SWM_WSI_MARKURGENT)
+				mark = workspace_mark_urgent;
+			else if (active && workspace_indicator & SWM_WSI_MARKACTIVE)
+				mark = workspace_mark_active;
+			else if (!active && workspace_indicator & SWM_WSI_MARKEMPTY)
+				mark = workspace_mark_empty;
 			else if (!collapse)
 				mark = " ";
 			else
 				mark = "";
 			strlcat(s, mark, sz);
 
-			if (named && workspace_indicator & SWM_WSI_PRINTNAMES)
+			if (named && workspace_indicator & SWM_WSI_PRINTNAMES){
 				snprintf(tmp, sizeof tmp, "%d:%s", ws->idx + 1,
 				    ws->name);
+			if (named && workspace_indicator &
+							SWM_WSI_NOINDEXES)
+				snprintf(tmp, sizeof tmp, "%s", ws->name);
+			}
+      else if (workspace_indicator & SWM_WSI_NOINDEXES)
+				snprintf(tmp, sizeof tmp, "%s", " ");
 			else
 				snprintf(tmp, sizeof tmp, "%d", ws->idx + 1);
 			strlcat(s, tmp, sz);
@@ -9612,7 +9632,10 @@ struct wsi_flag {
 	{"hidecurrent", SWM_WSI_HIDECURRENT},
 	{"markcurrent", SWM_WSI_MARKCURRENT},
 	{"markurgent", SWM_WSI_MARKURGENT},
+	{"markactive", SWM_WSI_MARKACTIVE},
+	{"markempty", SWM_WSI_MARKEMPTY},
 	{"printnames", SWM_WSI_PRINTNAMES},
+	{"noindexes", SWM_WSI_NOINDEXES},
 };
 
 #define SWM_FLAGS_DELIM		","
@@ -10014,6 +10037,15 @@ enum {
 	SWM_S_WORKSPACE_LIMIT,
 	SWM_S_WORKSPACE_INDICATOR,
 	SWM_S_WORKSPACE_NAME,
+	SWM_S_WORKSPACE_MARK_CURRENT,
+	SWM_S_WORKSPACE_MARK_URGENT,
+	SWM_S_WORKSPACE_MARK_ACTIVE,
+	SWM_S_WORKSPACE_MARK_EMPTY,
+	SWM_S_STACK_MARK_MAX,
+	SWM_S_STACK_MARK_VERTICAL,
+	SWM_S_STACK_MARK_VERTICAL_FLIP,
+	SWM_S_STACK_MARK_HORIZONTAL,
+	SWM_S_STACK_MARK_HORIZONTAL_FLIP,
 };
 
 int
@@ -10310,6 +10342,51 @@ setconfvalue(const char *selector, const char *value, int flags, char **emsg)
 			ewmh_update_desktop_names();
 			ewmh_get_desktop_names();
 		}
+		break;
+  case SWM_S_WORKSPACE_MARK_CURRENT:
+		free(workspace_mark_current);
+		if ((workspace_mark_current = strdup(value)) == NULL)
+			err(1, "setconfvalue: workspace_mark_current");
+		break;
+  case SWM_S_WORKSPACE_MARK_URGENT:
+		free(workspace_mark_urgent);
+		if ((workspace_mark_urgent = strdup(value)) == NULL)
+			err(1, "setconfvalue: workspace_mark_urgent");
+    break;
+  case SWM_S_WORKSPACE_MARK_ACTIVE:
+		free(workspace_mark_active);
+		if ((workspace_mark_active = strdup(value)) == NULL)
+			err(1, "setconfvalue: workspace_mark_active");
+    break;
+  case SWM_S_WORKSPACE_MARK_EMPTY:
+		free(workspace_mark_empty);
+		if ((workspace_mark_empty = strdup(value)) == NULL)
+			err(1, "setconfvalue: workspace_mark_empty");
+    break;
+  case SWM_S_STACK_MARK_MAX:
+		free(stack_mark_max);
+		if ((stack_mark_max = strdup(value)) == NULL)
+			err(1, "setconfvalue: stack_mark_max");
+		break;
+  case SWM_S_STACK_MARK_VERTICAL:
+		free(stack_mark_vertical);
+		if ((stack_mark_vertical = strdup(value)) == NULL)
+			err(1, "setconfvalue: stack_mark_vertical");
+		break;
+  case SWM_S_STACK_MARK_VERTICAL_FLIP:
+		free(stack_mark_vertical_flip);
+		if ((stack_mark_vertical_flip = strdup(value)) == NULL)
+			err(1, "setconfvalue: stack_mark_vertical_flip");
+		break;
+  case SWM_S_STACK_MARK_HORIZONTAL:
+		free(stack_mark_horizontal);
+		if ((stack_mark_horizontal = strdup(value)) == NULL)
+			err(1, "setconfvalue: stack_mark_horizontal");
+		break;
+  case SWM_S_STACK_MARK_HORIZONTAL_FLIP:
+		free(stack_mark_horizontal_flip);
+		if ((stack_mark_horizontal_flip = strdup(value)) == NULL)
+			err(1, "setconfvalue: stack_mark_horizontal_flip");
 		break;
 	default:
 		ALLOCSTR(emsg, "invalid option");
@@ -10727,6 +10804,15 @@ struct config_option configopt[] = {
 	{ "workspace_limit",		setconfvalue,	SWM_S_WORKSPACE_LIMIT },
 	{ "workspace_indicator",	setconfvalue,	SWM_S_WORKSPACE_INDICATOR },
 	{ "name",			setconfvalue,	SWM_S_WORKSPACE_NAME },
+	{ "workspace_mark_current",			setconfvalue,	SWM_S_WORKSPACE_MARK_CURRENT },
+	{ "workspace_mark_urgent",			setconfvalue,	SWM_S_WORKSPACE_MARK_URGENT },
+	{ "workspace_mark_active",			setconfvalue,	SWM_S_WORKSPACE_MARK_ACTIVE },
+	{ "workspace_mark_empty",			setconfvalue,	SWM_S_WORKSPACE_MARK_EMPTY },
+	{ "stack_mark_max",			setconfvalue,	SWM_S_STACK_MARK_MAX },
+	{ "stack_mark_vertical",			setconfvalue,	SWM_S_STACK_MARK_VERTICAL },
+	{ "stack_mark_vertical_flip",			setconfvalue,	SWM_S_STACK_MARK_VERTICAL_FLIP },
+	{ "stack_mark_horizontal",			setconfvalue,	SWM_S_STACK_MARK_HORIZONTAL },
+	{ "stack_mark_horizontal_flip",			setconfvalue,	SWM_S_STACK_MARK_HORIZONTAL_FLIP },
 };
 
 void
@@ -13308,8 +13394,31 @@ setup_globals(void)
 	if ((clock_format = strdup("%a %b %d %R %Z %Y")) == NULL)
 		err(1, "clock_format: strdup");
 
+	if ((stack_mark_max = strdup("[ ]")) == NULL)
+		err(1, "stack_mark_max: strdup");
+
+	if ((stack_mark_vertical = strdup("[|]")) == NULL)
+		err(1, "stack_mark_vertical: strdup");
+
+	if ((stack_mark_vertical_flip = strdup("[>]")) == NULL)
+		err(1, "stack_mark_vertical_flip: strdup");
+
+	if ((stack_mark_horizontal = strdup("[-]")) == NULL)
+		err(1, "stack_mark_horizontal: strdup");
+
+	if ((stack_mark_horizontal_flip = strdup("[v]")) == NULL)
+		err(1, "stack_mark_horizontal_flip: strdup");
+
 	if ((syms = xcb_key_symbols_alloc(conn)) == NULL)
 		errx(1, "unable to allocate key symbols.");
+  if ((workspace_mark_current = strdup ("*")) == NULL)
+      err(1, "workspace_mark_current: strdup");
+  if ((workspace_mark_urgent = strdup ("!")) == NULL)
+      err(1, "workspace_mark_urgent: strdup");
+  if ((workspace_mark_active = strdup ("^")) == NULL)
+      err(1, "workspace_mark_active: strdup");
+  if ((workspace_mark_empty = strdup ("-")) == NULL)
+      err(1, "workspace_mark_empty: strdup");
 
 	a_state = get_atom_from_string("WM_STATE");
 	a_prot = get_atom_from_string("WM_PROTOCOLS");
@@ -13494,6 +13603,15 @@ shutdown_cleanup(void)
 	free(bar_fonts);
 	free(clock_format);
 	free(startup_exception);
+	free(stack_mark_max);
+	free(stack_mark_vertical);
+	free(stack_mark_vertical_flip);
+	free(stack_mark_horizontal);
+	free(stack_mark_horizontal_flip);
+	free(workspace_mark_current);
+	free(workspace_mark_urgent);
+	free(workspace_mark_active);
+	free(workspace_mark_empty);
 
 	if (bar_fs)
 		XFreeFontSet(display, bar_fs);

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -46,8 +46,17 @@
 # bar_justify		= left
 # bar_format		= +N:+I +S <+D>+4<%a %b %d %R %Z %Y+8<+A+4<+V
 # workspace_indicator	= listcurrent,listactive,markcurrent,printnames
+# workspace_mark_current = *
+# workspace_mark_urgent = !
+# workspace_mark_active = ^
+# workspace_mark_empty = -
 # bar_at_bottom		= 1
 # stack_enabled		= 1
+# stack_mark_max = [ ]
+# stack_mark_vertical = [|]
+# stack_mark_vertical_flip = [>]
+# stack_mark_horizontal= [-]
+# stack_mark_horizontal_flip = [v]
 # clock_enabled		= 1
 # clock_format		= %a %b %d %R %Z %Y
 # iconic_enabled	= 0


### PR DESCRIPTION
Hello spectrwm team

I have added the following features.

`printonlynames` will print name of workspaces without numbers and the ":" separator.

`printnothing` will print nothing, this won't be used unless `custommarks_enabled` is set to `1`, this option allows for some cool effects in the workspaces indicator with nerd fonts for example.

`markactive` mark active workspcaces, won't work unless `custommarks_enabled` is set to `1`

`markempty` mark empty workspaces, won't work unless `custommarks_enabled` is set to `1`

`custommarks_enabled` enable the ability to use custom mark symbols for the workspace states.

`current_mark, urgent-mark, active_mark, empty_mark` use custom marks for workspace states, won't work unless `custommarks_enabled` is set to `1`

#343 