### PR TITLE
Add `ld_preload_enabled` option to disable use of LD_PRELOAD

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -508,6 +508,12 @@ the
 option.
 .Pp
 This setting is not retained at restart.
+.It Ic ld_preload_enabled
+When set to 0, 
+.Pa libswmhack.so
+is not added to 
+.Pa LD_PRELOAD .
+Defaults to 1.
 .It Ic maximize_hide_bar
 When set to 1,
 .Ic maximize_toggle

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -132,3 +132,7 @@
 # quirk[Xitk:Xine Window]			= FLOAT + ANYWHERE
 # quirk[xine:xine Video Fullscreen Window] = FULLSCREEN + FLOAT
 # quirk[pcb:pcb]				= FLOAT
+
+# To disable use of LD_PRELOAD, set:
+# ld_preload_enabled = 0
+


### PR DESCRIPTION
In some setups, spectrwm's use of LD_PRELOAD can break things.

In a specific case, spectrwm was installed using the guix package manager on a non-guix Linux distribution. In such a setup, there can be two conflicting versions of basic libraries such as libc, one in /gnu/store, the other in /lib64. spectrwm set LD_PRELOAD to a library in /gnu/store. If one starts a distribution (non-guix) binary, e.g. xterm, via dmenu, it will have LD_PRELOAD in /gnu/store, and load further libraries from there which can be incompatible. xterm crashed immediately.

