### PR TITLE
Add "wpath" pledge for OpenBSD on Sparc64

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -13628,7 +13628,7 @@ main(int argc, char *argv[])
 	if (setlocale(LC_CTYPE, "") == NULL || setlocale(LC_TIME, "") == NULL)
 		warnx("no locale support");
 
-	if (pledge("stdio proc exec rpath getpw dns inet unix", NULL) == -1)
+	if (pledge("stdio proc exec rpath getpw dns inet unix wpath", NULL) == -1)
 		err(1, "pledge");
 
 	/* handle some signals */
@@ -13648,7 +13648,7 @@ main(int argc, char *argv[])
 	if ((display = XOpenDisplay(0)) == NULL)
 		errx(1, "unable to open display");
 
-	if (pledge("stdio proc exec rpath getpw", NULL) == -1)
+	if (pledge("stdio proc exec rpath getpw wpath", NULL) == -1)
 		err(1, "pledge");
 
 	conn = XGetXCBConnection(display);
@@ -13703,7 +13703,7 @@ main(int argc, char *argv[])
 	else
 		scan_config();
 
-	if (pledge("stdio proc exec rpath", NULL) == -1)
+	if (pledge("stdio proc exec rpath wpath", NULL) == -1)
 		err(1, "pledge");
 
 	validate_spawns();


### PR DESCRIPTION
Hello,

Spectrwm is crashing on my OpenBSD Sparc64 box.

ktrace:
```
 70801 spectrwm CALL  open(0x7904d18380,0x10002<O_RDWR|O_CLOEXEC>)
 70801 spectrwm NAMI  "/var/cache/fontconfig//7908e75dfa020c169504380270e5263a-be64.cache-7"
 70801 spectrwm PLDG  open, "wpath", errno 1 Operation not permitted
 70801 spectrwm PSIG  SIGABRT SIG_DFL
```

This pull request adds the wpath pledge. This fixed the crash.
