### PR TITLE
openbsd: print current cpu stats

### DIFF
--- a/baraction.sh
+++ b/baraction.sh
@@ -84,7 +84,7 @@ print_bat() {
 APM_DATA=""
 I=0
 while :; do
-	IOSTAT_DATA=`/usr/sbin/iostat -C | grep '[0-9]$'`
+	IOSTAT_DATA=`/usr/sbin/iostat -C -c 2 | tail -n 1 | grep '[0-9]$'`
 	if [ $I -eq 0 ]; then
 		APM_DATA=`/usr/sbin/apm -alb`
 	fi


### PR DESCRIPTION
The first line of iostat(8) displays the stats from the time of the last reboot.  Show the current stats instead by grabbing and displaying
the second line.

From mglocker@