### PR TITLE
Disable border for max windows if disable_border=always (closes #379)

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -422,8 +422,7 @@ Remove border when bar is disabled and there is only one window on the region.
 Enable by setting to 1.
 Setting this to
 .Ar always
-removes border from lone tiled windows, regardless of the bar being
-enabled/disabled.
+removes the border regardless of the bar being enabled/disabled.
 Defaults to 0.
 .It Ic focus_close
 Window to put focus when the focused window is closed.

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -6061,6 +6061,10 @@ update_floater(struct ws_win *win)
 			win->bordered = false;
 		}
 
+		if (disable_border_always) {
+			win->bordered = false;
+		}
+
 		if (win->bordered) {
 			/* Window geometry excludes frame. */
 			X(win) += border_width;
@@ -6531,8 +6535,9 @@ max_stack(struct workspace *ws, struct swm_geometry *g)
 		    HEIGHT(w) != gg.h) {
 			w->g = gg;
 
-			if (disable_border &&
-			    !(bar_enabled && ws->bar_enabled)) {
+			if (disable_border_always ||
+			    (disable_border &&
+			    !(bar_enabled && ws->bar_enabled))) {
 				w->bordered = false;
 				WIDTH(w) += 2 * border_width;
 				HEIGHT(w) += 2 * border_width;


### PR DESCRIPTION
#379: If `disable_border=always`, remove borders from maximized windows, even if the bar is enabled.