### PR TITLE
Simplify use of pledge(2) on OpenBSD

### DIFF
--- a/freebsd/Makefile
+++ b/freebsd/Makefile
@@ -27,7 +27,6 @@ all: spectrwm libswmhack.so.$(LVERS)
 spectrwm.c:
 	ln -sf ../spectrwm.c
 	ln -sf ../version.h
-	ln -sf ../linux/pledge.h
 	ln -sf ../linux/queue_compat.h
 
 swm_hack.c:
@@ -52,7 +51,7 @@ install: all
 	ln -sf spectrwm $(SWM_BINDIR)/scrotwm
 
 clean:
-	rm -f spectrwm *.o *.so libswmhack.so.* spectrwm.c swm_hack.c version.h pledge.h queue_compat.h
+	rm -f spectrwm *.o *.so libswmhack.so.* spectrwm.c swm_hack.c version.h queue_compat.h
 
 .PHONY:	all install clean
 

--- a/linux/pledge.h
+++ b/linux/pledge.h
@@ -1,1 +1,0 @@
-#define	pledge(promises, execpromises)	(0)

--- a/netbsd/Makefile
+++ b/netbsd/Makefile
@@ -25,7 +25,6 @@ all: spectrwm libswmhack.so.$(LVERS)
 spectrwm.c:
 	ln -sf ../spectrwm.c
 	ln -sf ../version.h
-	ln -sf ../linux/pledge.h
 	ln -sf ../linux/queue_compat.h
 
 swm_hack.c:
@@ -50,7 +49,7 @@ install: all
 	ln -sf spectrwm $(SWM_BINDIR)/scrotwm
 
 clean:
-	rm -f spectrwm *.o *.so libswmhack.so.* spectrwm.c swm_hack.c version.h pledge.h queue_compat.h
+	rm -f spectrwm *.o *.so libswmhack.so.* spectrwm.c swm_hack.c version.h queue_compat.h
 
 .PHONY:	all install clean
 

--- a/osx/Makefile
+++ b/osx/Makefile
@@ -37,7 +37,6 @@ spectrwm.c:
 	ln -sf ../linux/tree.h
 	ln -sf ../spectrwm.c
 	ln -sf ../version.h
-	ln -sf ../linux/pledge.h
 	ln -sf ../linux/queue_compat.h
 
 swm_hack.c:
@@ -66,6 +65,6 @@ install: all
 	ln -sf libswmhack.so.0.0 $(DESTDIR)$(LIBDIR)/libswmhack.so
 
 clean:
-	rm -f spectrwm *.o *.so libswmhack.so.* spectrwm.c swm_hack.c tree.h version.h pledge.h queue_compat.h
+	rm -f spectrwm *.o *.so libswmhack.so.* spectrwm.c swm_hack.c tree.h version.h queue_compat.h
 
 .PHONY: all install clean

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -49,9 +49,6 @@
 #include <fcntl.h>
 #include <locale.h>
 #include <paths.h>
-#if !defined(__OpenBSD__)
-#include "pledge.h"
-#endif
 #include <pwd.h>
 #include <regex.h>
 #include <signal.h>
@@ -3759,9 +3756,6 @@ xft_init(struct swm_region *r)
 		else
 			font_pua_index = num_xftfonts;
 	}
-
-	if (pledge("stdio proc exec", NULL) == -1)
-		err(1, "pledge");
 
 	for (i = 0; i < num_fg_colors; i++) {
 		PIXEL_TO_XRENDERCOLOR(r->s->c[SWM_S_COLOR_BAR_FONT+i].pixel,
@@ -13784,9 +13778,6 @@ main(int argc, char *argv[])
 	if (setlocale(LC_CTYPE, "") == NULL || setlocale(LC_TIME, "") == NULL)
 		warnx("no locale support");
 
-	if (pledge("stdio proc exec rpath getpw dns inet unix wpath", NULL) == -1)
-		err(1, "pledge");
-
 	/* handle some signals */
 	bzero(&sact, sizeof(sact));
 	sigemptyset(&sact.sa_mask);
@@ -13803,9 +13794,6 @@ main(int argc, char *argv[])
 
 	if ((display = XOpenDisplay(0)) == NULL)
 		errx(1, "unable to open display");
-
-	if (pledge("stdio proc exec rpath getpw wpath", NULL) == -1)
-		err(1, "pledge");
 
 	conn = XGetXCBConnection(display);
 	if (xcb_connection_has_error(conn))
@@ -13859,9 +13847,6 @@ main(int argc, char *argv[])
 	else
 		scan_config();
 
-	if (pledge("stdio proc exec rpath wpath", NULL) == -1)
-		err(1, "pledge");
-
 	validate_spawns();
 
 	if (getenv("SWM_STARTED") == NULL)
@@ -13872,6 +13857,11 @@ main(int argc, char *argv[])
 	for (i = 0; i < num_screens; i++)
 		TAILQ_FOREACH(r, &screens[i].rl, entry)
 			bar_setup(r);
+
+#ifdef __OpenBSD__
+	if (pledge("stdio proc exec", NULL) == -1)
+		err(1, "pledge");
+#endif
 
 	/* Manage existing windows. */
 	grab_windows();
@@ -13956,9 +13946,6 @@ main(int argc, char *argv[])
 		xcb_flush(conn);
 	}
 done:
-	if (pledge("stdio proc", NULL) == -1)
-		err(1, "pledge");
-
 	shutdown_cleanup();
 
 	return (0);


### PR DESCRIPTION
`pledge(2)` is currently used multiple times, dropping privileges
gradually. OpenBSD typically does things differently: it sets everything
up, restricts itself using `pledge(2)` and goes into a running state.

There is no clear advantage in dropping privileges gradually, and makes
debugging harder. Proposal is to follow OpenBSD's typical style (e.g. as
used in `cwm(1)` and only pledge one time. Benefit of this is that this
simplifies things.