### PR TITLE
Check X connection and terminate when it is gone.

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -13933,6 +13933,9 @@ main(int argc, char *argv[])
 		if (!running)
 			goto done;
 
+		if(xcb_connection_has_error(conn))
+			goto done;
+
 		if (stdin_ready) {
 			stdin_ready = false;
 			bar_extra_update();


### PR DESCRIPTION
The X connection is never explicitly checked in the main loop. When the X connection is terminated, spectrwm keeps running.

Unfortunately the bar update logic does a call (https://github.com/conformal/spectrwm/blob/master/spectrwm.c#L2611) which leads to the termination of spectrwm. So while the bar is shown, killing X also leads spectrwm to terminate. If the bar is not shown, this call is not made and spectrwm kept running. This masked the issue.

Fixes: https://github.com/conformal/spectrwm/issues/474

In this PR I check the X connection explicitly in the main loop. However, `xcb_flush(conn)` is called various times and it returns `<= 0` on failure. This could be used to detect connection issues as well.