### PR TITLE
linux: Don't include sys/cdefs.h

### DIFF
--- a/linux/linux.c
+++ b/linux/linux.c
@@ -1,7 +1,6 @@
 #include <sys/types.h>
 
 #include <errno.h>
-#include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/linux/linux.c
+++ b/linux/linux.c
@@ -1,5 +1,4 @@
 #include <sys/types.h>
-#include <sys/cdefs.h>
 
 #include <errno.h>
 #include <errno.h>

--- a/osx/osx.c
+++ b/osx/osx.c
@@ -2,7 +2,6 @@
 #include <sys/cdefs.h>
 
 #include <errno.h>
-#include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This include is unused and not shipped by musl.

Gentoo Bug: https://bugs.gentoo.org/712976
Reference: https://wiki.musl-libc.org/faq.html#Q:-When-compiling-something-against-musl,-I-get-error-messages-about-%3Ccode%3Esys/cdefs.h%3C/code%3E