### PR TITLE
linux: Expand Makefile variables when set

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -8,26 +8,26 @@ DOCDIR       ?= $(DATAROOTDIR)/doc/spectrwm
 XSESSIONSDIR ?= $(DATAROOTDIR)/xsessions
 PKG_CONFIG   ?= pkg-config
 
-BUILDVERSION    = $(shell sh $(CURDIR)/../buildver.sh)
-LIBVERSION      = $(shell .  $(CURDIR)/../lib/shlib_version; echo $$major.$$minor)
-LIBMAJORVERSION = $(shell .  $(CURDIR)/../lib/shlib_version; echo $$major)
+BUILDVERSION    := $(shell sh $(CURDIR)/../buildver.sh)
+LIBVERSION      := $(shell .  $(CURDIR)/../lib/shlib_version; echo $$major.$$minor)
+LIBMAJORVERSION := $(shell .  $(CURDIR)/../lib/shlib_version; echo $$major)
 
-MAINT_CFLAGS   = -std=c99 -Wmissing-prototypes -Wall -Wextra -Wshadow -Wno-uninitialized -g
-MAINT_LDFLAGS  = -Wl,--as-needed
-MAINT_CPPFLAGS = -I. -D_GNU_SOURCE -DSWM_LIB=\"$(LIBDIR)/libswmhack.so.$(LIBVERSION)\"
+MAINT_CFLAGS   := -std=c99 -Wmissing-prototypes -Wall -Wextra -Wshadow -Wno-uninitialized -g
+MAINT_LDFLAGS  := -Wl,--as-needed
+MAINT_CPPFLAGS := -I. -D_GNU_SOURCE -DSWM_LIB=\"$(LIBDIR)/libswmhack.so.$(LIBVERSION)\"
 
 ifneq ("${BUILDVERSION}", "")
 MAINT_CPPFLAGS += -DSPECTRWM_BUILDSTR=\"$(BUILDVERSION)\"
 endif
 
-BIN_CFLAGS   = -fPIE
-BIN_LDFLAGS  = -fPIE -pie
-BIN_CPPFLAGS = $(shell $(PKG_CONFIG) --cflags x11 x11-xcb xcb-icccm xcb-keysyms xcb-randr xcb-util xcb-xinput xcb-xtest xcursor xft)
-BIN_LDLIBS   = $(shell $(PKG_CONFIG) --libs   x11 x11-xcb xcb-icccm xcb-keysyms xcb-randr xcb-util xcb-xinput xcb-xtest xcursor xft)
-LIB_CFLAGS   = -fPIC
-LIB_LDFLAGS  = -fPIC -shared
-LIB_CPPFLAGS = $(shell $(PKG_CONFIG) --cflags x11)
-LIB_LDLIBS   = $(shell $(PKG_CONFIG) --libs   x11) -ldl
+BIN_CFLAGS   := -fPIE
+BIN_LDFLAGS  := -fPIE -pie
+BIN_CPPFLAGS := $(shell $(PKG_CONFIG) --cflags x11 x11-xcb xcb-icccm xcb-keysyms xcb-randr xcb-util xcb-xinput xcb-xtest xcursor xft)
+BIN_LDLIBS   := $(shell $(PKG_CONFIG) --libs   x11 x11-xcb xcb-icccm xcb-keysyms xcb-randr xcb-util xcb-xinput xcb-xtest xcursor xft)
+LIB_CFLAGS   := -fPIC
+LIB_LDFLAGS  := -fPIC -shared
+LIB_CPPFLAGS := $(shell $(PKG_CONFIG) --cflags x11)
+LIB_LDLIBS   := $(shell $(PKG_CONFIG) --libs   x11) -ldl
 
 all: spectrwm libswmhack.so.$(LIBVERSION)
 

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -12,7 +12,7 @@ BUILDVERSION    := $(shell sh $(CURDIR)/../buildver.sh)
 LIBVERSION      := $(shell .  $(CURDIR)/../lib/shlib_version; echo $$major.$$minor)
 LIBMAJORVERSION := $(shell .  $(CURDIR)/../lib/shlib_version; echo $$major)
 
-MAINT_CFLAGS   := -std=c99 -Wmissing-prototypes -Wall -Wextra -Wshadow -Wno-uninitialized -g
+MAINT_CFLAGS   := -std=c99 -Wmissing-prototypes -Wall -Wextra -Wshadow -g
 MAINT_LDFLAGS  := -Wl,--as-needed
 MAINT_CPPFLAGS := -I. -D_GNU_SOURCE -DSWM_LIB=\"$(LIBDIR)/libswmhack.so.$(LIBVERSION)\"
 


### PR DESCRIPTION
With `make(1)` variables set with `:=` are expanded when they are set and variables set with `=` are expanded when they are used.

Reference: https://www.gnu.org/software/make/manual/make.html#Flavors