### PR TITLE
linux: Fix build with clang 16

### DIFF
--- a/linux/linux.c
+++ b/linux/linux.c
@@ -154,9 +154,7 @@ strlcat(char *dst, const char *src, size_t siz)
  */
 
 char *
-fgetln(fp, len)
-	FILE *fp;
-	size_t *len;
+fgetln(FILE *fp, size_t *len)
 {
 	static char *buf = NULL;
 	static size_t bufsiz = 0;


### PR DESCRIPTION
This is not supported in future clang versions.

error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype

Reference: https://archives.gentoo.org/gentoo-dev/message/dd9f2d3082b8b6f8dfbccb0639e6e240