### PR TITLE
linux: Don't force building debugging symbols

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -12,7 +12,7 @@ BUILDVERSION    := $(shell sh $(CURDIR)/../buildver.sh)
 LIBVERSION      := $(shell .  $(CURDIR)/../lib/shlib_version; echo $$major.$$minor)
 LIBMAJORVERSION := $(shell .  $(CURDIR)/../lib/shlib_version; echo $$major)
 
-MAINT_CFLAGS   := -std=c99 -Wmissing-prototypes -Wall -Wextra -Wshadow -g
+MAINT_CFLAGS   := -std=c99 -Wmissing-prototypes -Wall -Wextra -Wshadow
 MAINT_LDFLAGS  := -Wl,--as-needed
 MAINT_CPPFLAGS := -I. -D_GNU_SOURCE -DSWM_LIB=\"$(LIBDIR)/libswmhack.so.$(LIBVERSION)\"
 


### PR DESCRIPTION
Setting `-g` should be up to the user and can be set in the `CFLAGS` environment variable. Building debugging symbols is slower especially on weaker hardware and will cause an increase in disk writes. Additionally many distros will just strip the symbols away making this wasteful.