### PR TITLE
fix crash due to invalid window

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -5141,7 +5141,7 @@ get_focus_magic(struct ws_win *win)
 
 	winfocus = find_main_window(win);
 
-	if (winfocus->focus_redirect == NULL)
+	if (winfocus == NULL || winfocus->focus_redirect == NULL)
 		return (winfocus);
 
 	/* Put limit just in case a redirect loop exists. */
@@ -6968,6 +6968,12 @@ find_main_window(struct ws_win *win)
 {
 	struct ws_win	*w;
 	int		i, wincount;
+
+	/* window can have been freed */
+	if (validate_win(win)) {
+		DNPRINTF(SWM_D_EVENT, "invalid win\n");
+		return (NULL);
+	}
 
 	if (win == NULL || !TRANS(win))
 		return (win);


### PR DESCRIPTION
avoid use after free by checking if the win is valid before accessing it. got a crash hardway running ssh-askpass(1) on OpenBSD/xenocara.

#0  0x000008e492570e62 in count_win (ws=<optimized out>, 
    flags=<error reading variable: Cannot access memory at address 0x7>) at spectrwm.c:4191
#1  find_main_window (win=0x8e765b1a640) at spectrwm.c:6978
#2  get_focus_magic (win=0x8e765b1a640) at spectrwm.c:5142
#3  0x000008e492582739 in unmapnotify (e=<optimized out>) at spectrwm.c:13268
#4  0x000008e492585265 in main (argc=<optimized out>, argv=<optimized out>) at spectrwm.c:14658

How to reproduce:
run ssh-askpass(1), upon exiting, it implicitly calls XDestroyWindow() / XFree()