### PR TITLE
Add new `bar_color_unfocus` and `bar_font_color_unfocus` options.

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -197,6 +197,11 @@ Any of these colors can then be selected as a background color in the status
 bar through the use of the markup sequence
 .Ic +@bg=n;\&
 where n is between 0 and 9.
+.It Ic bar_color_unfocus Ns Bq Ar x
+Background color of the status bar(s) on unfocused screen(s)
+.Ar x .
+Defaults to the value of
+.Ic bar_color .
 .It Ic bar_color_selected Ns Bq Ar x
 Background color for selections on the status bar(s) in screen
 .Ar x .
@@ -267,6 +272,15 @@ Any of these colors can then be selected as a foreground color in the status
 bar through the use of the markup sequence
 .Ic +@fg=n;\&
 where n is between 0 and 9.
+.It Ic bar_font_color_unfocus Ns Bq Ar x
+Foreground color of the status bar(s) on unfocused screen(s)
+.Ar x .
+.Pp
+A comma separated list of up to 10 colors can be specified, with the same
+syntax and behavior as
+.Ic bar_font_color
+for unfocused bar(s). Defaults to the value of
+.Ic bar_font_color .
 .It Ic bar_font_color_selected Ns Bq Ar x
 Foreground color for selections on the status bar(s) in screen
 .Ar x .

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -2575,6 +2575,7 @@ bar_print_layout(struct swm_region *r)
 	struct text_fragment	*frag;
 	xcb_rectangle_t		rect;
 	XftDraw			*xft_draw = NULL;
+	XRectangle		x_rect;
 	XftFont			*xf;
 	GC			draw = 0;
 	XGCValues		gcvd;
@@ -2682,6 +2683,16 @@ bar_print_layout(struct swm_region *r)
 		/* No space to draw anything else */
 		if (rect.width < SWM_BAR_OFFSET)
 			continue;
+
+		/* Set the clip rectangle to avoid text overflow */
+		x_rect.x = rect.x;
+		x_rect.y = rect.y;
+		x_rect.width = rect.width;
+		x_rect.height = rect.height;
+		if (bar_font_legacy)
+			XSetClipRectangles(display, draw, 0, 0, &x_rect, 1, YXBanded);
+		else
+			XftDrawSetClipRectangles(xft_draw, 0, 0, &x_rect, 1);
 
 		/* Draw the text fragments in the current section */
 		xpos = bsect[i].text_start;


### PR DESCRIPTION
I wanted the bar of focused screens to 'pop' a little bit more. We can set the bar border color, but that didn't give me enough visual cue unless I made it too big.

For this reason I introduced two new options to change the foreground/background colors of the bar depending on the focused region which after a few tries I came to really like. This allowed me to disable the bar border completely. See this clip to see the behavior with two screens, alternating in focus:

https://www.thregr.org/~wavexx/tmp/spectrwm-test.webp (uploaded elsewhere due to gh refusing webp)

Both default to the same focused colors (without suffix), resulting in no change in behavior without the extra new customization.

I currently based this on `release3.5` as I wanted to test the new tweaks to the region rotation flags, but I can rebase if needed.