### PR TITLE
Do not display workspaces exceeding workspace_limit in the bar

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -4010,6 +4010,9 @@ bar_workspace_indicator(char *s, size_t sz, struct swm_region *r)
 		if (ws_root(ws))
 			continue;
 
+		if(ws->idx >= workspace_limit)
+			continue;
+
 		current = (ws == r->ws);
 		named = (ws->name != NULL);
 		urgent = false;


### PR DESCRIPTION
If I set the workspace_limit to 10, but then start a program on WS11 (for example via _SWM_WM=11 ./program), then magically WS 11 appears in the bar.

I'm not sure if this is intended, but I'd rather like to limit the bar to the configured limit and use WS 11 as invisible WS only accessible by scripts.