### PR TITLE
Improve documentation around libswmhack.so

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -1793,7 +1793,11 @@ of workspaces and regions.
 .It XTERM_FONTADJ
 Adjust
 .Xr xterm 1
-fonts when resizing.
+fonts when resizing. Note that this needs
+.Pa libswmhack.so
+to work. See the
+.Sx SWMHACK
+section below.
 .El
 .Pp
 Custom quirks in the configuration file are specified as follows:

--- a/spectrwm.1
+++ b/spectrwm.1
@@ -2076,6 +2076,15 @@ quirk[XTerm:ws2] = WS[2]
 .Pp
 Note that XCB programs are currently unsupported by
 .Pa libswmhack.so .
+.Pp
+If the "spawn-in-workspace" behavior is not desired, it is possible to disable
+it globally by setting the
+.Pa IGNORESPAWNWS
+and
+.Pa IGNOREPID
+quirks for all windows:
+.Bd -literal -offset indent
+quirk[.*] += IGNORESPAWNWS + IGNOREPID
 .Sh SIGNALS
 Sending
 .Nm

--- a/spectrwm.html
+++ b/spectrwm.html
@@ -1795,6 +1795,13 @@ quirk[XTerm:ws2] = WS[2]</pre>
 </div>
 <p class="Pp">Note that XCB programs are currently unsupported by
     <span class="Pa">libswmhack.so</span>.</p>
+<p class="Pp">If the &quot;spawn-in-workspace&quot; behavior is not desired, it
+    is possible to disable it globally by setting the
+    <span class="Pa">IGNORESPAWNWS</span> and <span class="Pa">IGNOREPID</span>
+    quirks for all windows:</p>
+<div class="Bd Pp Bd-indent Li">
+<pre>quirk[.*] += IGNORESPAWNWS + IGNOREPID</pre>
+</div>
 </section>
 <section class="Sh">
 <h1 class="Sh" id="SIGNALS"><a class="permalink" href="#SIGNALS">SIGNALS</a></h1>

--- a/spectrwm.html
+++ b/spectrwm.html
@@ -1596,7 +1596,9 @@ bind[move] = MOD+Button3</pre>
       -1 to put the window into free mode so that it is mapped independent of
       workspaces and regions.</dd>
   <dt>XTERM_FONTADJ</dt>
-  <dd>Adjust <a class="Xr">xterm(1)</a> fonts when resizing.</dd>
+  <dd>Adjust <a class="Xr">xterm(1)</a> fonts when resizing. Note that this
+      needs <span class="Pa">libswmhack.so</span> to work. See the
+      <a class="Sx" href="#SWMHACK">SWMHACK</a> section below.</dd>
 </dl>
 </div>
 <p class="Pp">Custom quirks in the configuration file are specified as


### PR DESCRIPTION
Provides users with a convenient way to opt-out of `libswmhack.so` usage if they so desire.