### PR TITLE
Show how to disable "spawn-in-workspace" in configuration file

### DIFF
--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -176,3 +176,6 @@
 #quirk[Xitk:Xine Window]			= FLOAT + ANYWHERE
 #quirk[xine:xine Video Fullscreen Window]	= FULLSCREEN + FLOAT
 #quirk[pcb:pcb]				= FLOAT
+
+# To disable spectrwm's default "spawn-in-workspace" behavior:
+#quirk[.*] += IGNORESPAWNWS + IGNOREPID


### PR DESCRIPTION
The manual page is quite big, so it's very possible to miss it the relevant part. Having a commented out line in the default configuration file makes it much more discoverable.