### PR TITLE
Urgent windows border color

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -494,6 +494,13 @@ rgb:88/88/00.
 Border color of unfocused maximized windows that are in free mode.
 Defaults to the value of
 .Ic color_unfocus_free .
+.It Ic color_urgent_free
+Border color of urgent windows that are in free mode, default is
+rgb:b8/86/0b.
+.It Ic color_urgent_maximized_free
+Border color of urgent maximized windows that are in free mode.
+Defaults to the value of
+.Ic color_urgent_free .
 .It Ic color_focus
 Border color of the currently focused window.
 Default is red.
@@ -507,6 +514,12 @@ Border color of unfocused windows, default is rgb:88/88/88.
 Border color of unfocused, maximized windows.
 Defaults to the value of
 .Ic color_unfocus .
+.It Ic color_urgent
+Border color of urgent windows, default is rgb:ff/a5/00.
+.It Ic color_urgent_maximized
+Border color of urgent, maximized windows.
+Defaults to the value of
+.Ic color_urgent .
 .It Ic cycle_visible
 Include workspaces that are mapped when switching with
 .Ic ws_next ,
@@ -1142,6 +1155,7 @@ program is spawned:
 .It Cm $bar_font_color_selected
 .It Cm $color_focus
 .It Cm $color_unfocus
+.It Cm $color_urgent
 .It Cm $dmenu_bottom
 \-b if
 .Ic bar_at_bottom

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -33,10 +33,14 @@
 #color_focus_maximized	= yellow
 #color_unfocus		= rgb:88/88/88
 #color_unfocus_maximized	= rgb:88/88/00
+#color_urgent		= rgb:ff/a5/00
+#color_urgent_maximized	= rgb:ff/a5/00
 #color_focus_free	= cyan
 #color_focus_maximized_free	= magenta
 #color_unfocus_free	= rgb:00/88/88
 #color_unfocus_maximized_free	= rgb:88/00/88
+#color_urgent_free	= rgb:b8/86/0b
+#color_urgent_maximized_free	= rgb:b8/86/0b
 #region_padding		= 0
 #tile_gap		= 0
 


### PR DESCRIPTION
Add the relevant config options `color_urgent*`. The default colors were picked completely arbitrarily