### PR TITLE
fix focusing urgent windows on current workspace

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -7547,7 +7547,7 @@ focus(struct swm_screen *s, struct binding *bp, union arg *args)
 		head = cur_focus;
 		d = cws ? cws->idx : ws->idx;
 
-		for (i = 0; i <= workspace_limit; ++i) {
+		for (i = 0; i <= workspace_limit + 1; ++i) {
 			if (head == NULL) {
 				wws = workspace_lookup(s,
 				    (d + i + 1) % (workspace_limit + 1) - 1);


### PR DESCRIPTION
Fix `focus_urgent` not focusing previous urgent windows in the current workspace.

Alternative patch, which prioritizes previous urgent windows in the current workspace over urgent windows in the next workspaces:

```
diff --git a/spectrwm.c b/spectrwm.c
index 282ca0a..ad6017a 100644
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -7569,6 +7569,21 @@ focus(struct swm_screen *s, struct binding *bp, union arg *args)
 				head = TAILQ_NEXT(head, entry);
 			}
 
+			if (i == 0 && !winfocus) {
+				head = TAILQ_FIRST(&(cws ? cws : ws)->winlist);
+				while (head) {
+					if (head == cur_focus) {
+						head = NULL;
+						break;
+					} else if (win_urgent(head)) {
+						winfocus = head;
+						break;
+					}
+
+					head = TAILQ_NEXT(head, entry);
+				}
+			}
+
 			if (winfocus)
 				break;
 		}
```