### PR TITLE
Ignore autoruns if restarting with `restart_of_day`

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -5947,8 +5947,10 @@ restart(struct swm_screen *s, struct binding *bp, union arg *args)
 
 	shutdown_cleanup();
 
-	if (args && args->id == SWM_ARG_ID_RESTARTOFDAY)
+	if (args && args->id == SWM_ARG_ID_RESTARTOFDAY) {
 		unsetenv("SWM_STARTED");
+		setenv("SWM_RESTART", "YES", 1);
+	}
 
 	execvp(start_argv[0], start_argv);
 	warn("execvp failed");
@@ -13976,7 +13978,7 @@ setautorun(uint8_t asop, const char *selector, const char *value, int flags,
 	(void)selector;
 	(void)flags;
 
-	if (getenv("SWM_STARTED"))
+	if (getenv("SWM_STARTED") || getenv("SWM_RESTART"))
 		return (0);
 
 	if (asopcheck(asop, SWM_ASOP_BASIC, emsg))
@@ -18014,6 +18016,9 @@ main(int argc, char *argv[])
 
 	if (getenv("SWM_STARTED") == NULL)
 		setenv("SWM_STARTED", "YES", 1);
+
+	if (getenv("SWM_RESTART"))
+		unsetenv("SWM_RESTART");
 
 	/* Setup bars on all regions. */
 	num_screens = get_screen_count();


### PR DESCRIPTION
Currently, if restarting with the `restart_of_day` function, any autoruns in the user config file are executed again. Since the general usecase for this function is to restart spectrwm while preserving layout settings (#172, #395, #445), it doesn't make sense to execute autoruns again.