### PR TITLE
Add Smart Gaps

### DIFF
--- a/spectrwm.1
+++ b/spectrwm.1
@@ -898,6 +898,9 @@ Note that rotation is used by
 .It Ic region_padding
 Pixel width of empty space within region borders.
 Disable by setting to 0.
+.It Ic smart_gaps
+No gaps if there is only a single window.
+Defaults to 0
 .It Ic snap_range
 Set the distance in pixels a tiled/maximized window must be moved (with the
 pointer) to unsnap and float freely.

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -536,6 +536,7 @@ bool		 disable_border_always = false;
 int		 border_width = 1;
 int		 region_padding = 0;
 int		 tile_gap = 0;
+bool		 smart_gaps = false;
 bool		 verbose_layout = false;
 bool		 debug_enabled;
 time_t		 time_started;
@@ -8289,6 +8290,13 @@ stack_master(struct workspace *ws, struct swm_geometry *g, int rot, bool flip)
 			Y(win) -= border_width;
 			WIDTH(win) += 2 * border_width;
 			HEIGHT(win) += 2 * border_width;
+			/* No Gaps if there is only one window per workspace */
+			if (smart_gaps) {
+				X(win) -= (border_width + region_padding);
+				Y(win) -= (border_width + region_padding);
+				WIDTH(win) += 2 * (border_width + region_padding);
+				HEIGHT(win) += 2 * (border_width + region_padding);
+			}
 		}
 
 		if (bordered != win->bordered) {
@@ -13305,6 +13313,7 @@ enum {
 	SWM_S_MAXIMIZE_HIDE_OTHER,
 	SWM_S_MAXIMIZED_UNFOCUS,
 	SWM_S_REGION_PADDING,
+	SWM_S_SMART_GAPS,
 	SWM_S_SNAP_RANGE,
 	SWM_S_SPAWN_ORDER,
 	SWM_S_SPAWN_TERM,
@@ -13552,6 +13561,9 @@ setconfvalue(uint8_t asop, const char *selector, const char *value, int flags,
 		region_padding = atoi(value);
 		if (region_padding < 0)
 			region_padding = 0;
+		break;
+	case SWM_S_SMART_GAPS:
+		smart_gaps = atoi(value);
 		break;
 	case SWM_S_SNAP_RANGE:
 		snap_range = atoi(value);
@@ -14222,6 +14234,7 @@ struct config_option configopt[] = {
 	{ "region_padding",		setconfvalue,	SWM_S_REGION_PADDING },
 	{ "screenshot_app",		NULL,		0 },	/* dummy */
 	{ "screenshot_enabled",		NULL,		0 },	/* dummy */
+	{ "smart_gaps",			setconfvalue,	SWM_S_SMART_GAPS },
 	{ "snap_range",			setconfvalue,	SWM_S_SNAP_RANGE },
 	{ "spawn_flags",		setconfspawnflags,0 },
 	{ "spawn_position",		setconfvalue,	SWM_S_SPAWN_ORDER },

--- a/spectrwm.conf
+++ b/spectrwm.conf
@@ -43,6 +43,7 @@
 #color_urgent_maximized_free	= rgb:b8/86/0b
 #region_padding		= 0
 #tile_gap		= 0
+#smart_gaps		= 0
 
 # Region containment
 # Distance window must be dragged/resized beyond the region edge before it is


### PR DESCRIPTION
Self explanatory. If there is only a single window per workspace, then show no gaps around window. ```disable_border = always``` is similar, but only removes the border. This PR removes the gaps too.

Toggleable via `smart_gaps`