### PR TITLE
fix pledge for newer systems

### DIFF
--- a/spectrwm.c
+++ b/spectrwm.c
@@ -18909,7 +18909,9 @@ main(int argc, char *argv[])
 			bar_setup(r);
 
 #ifdef __OpenBSD__
-	if (pledge("stdio proc exec", NULL) == -1)
+	if (unveil("/dev/null", "rw") == -1)
+		err(1, "unveil /dev/null");
+	if (pledge("stdio proc exec rpath wpath", NULL) == -1)
 		err(1, "pledge");
 #endif
 

--- a/spectrwm.c
+++ b/spectrwm.c
@@ -18909,8 +18909,6 @@ main(int argc, char *argv[])
 			bar_setup(r);
 
 #ifdef __OpenBSD__
-	if (unveil("/dev/null", "rw") == -1)
-		err(1, "unveil /dev/null");
 	if (pledge("stdio proc exec rpath wpath", NULL) == -1)
 		err(1, "pledge");
 #endif


### PR DESCRIPTION
pledge used to implicitly allow access to /dev/null with 'stdio', but it must now be granted 'rpath' and/or 'wpath' as needed. Since no other files need access we can restrict to just this with unveil.

Should fix #607